### PR TITLE
Return a real user-info data structure from the /api/login endpoint

### DIFF
--- a/arisia-remote/app/arisia/auth/LoginService.scala
+++ b/arisia-remote/app/arisia/auth/LoginService.scala
@@ -1,21 +1,23 @@
 package arisia.auth
 
+import arisia.models.{LoginUser, LoginId, LoginName}
+
 import scala.concurrent.Future
 
 trait LoginService {
   /**
    * Given credentials, says whether they match a known login.
    */
-  def checkLogin(id: String, password: String): Future[Boolean]
+  def checkLogin(id: String, password: String): Future[Option[LoginUser]]
 }
 
 class LoginServiceImpl extends LoginService {
-  def checkLogin(id: String, password: String): Future[Boolean] = {
+  def checkLogin(id: String, password: String): Future[Option[LoginUser]] = {
     // TODO: make this real
     val result = if (id == "joe" && password == "volcano")
-      true
+      Some(LoginUser(LoginId("joe"), LoginName("Joe Banks")))
     else
-      false
+      None
 
     Future.successful(result)
   }

--- a/arisia-remote/app/arisia/models/LoginUser.scala
+++ b/arisia-remote/app/arisia/models/LoginUser.scala
@@ -1,0 +1,18 @@
+package arisia.models
+
+import arisia.util.{StdString, StdStringUtils}
+import play.api.libs.json.{Format, Json}
+
+case class LoginId(v: String) extends StdString
+object LoginId extends StdStringUtils(new LoginId(_))
+
+case class LoginName(v: String) extends StdString
+object LoginName extends StdStringUtils(new LoginName(_))
+
+case class LoginUser(
+  id: LoginId,
+  name: LoginName
+)
+object LoginUser {
+  implicit val fmt: Format[LoginUser] = Json.format
+}


### PR DESCRIPTION
On success, returns
```
{"id":"...","name":"..."}
```
In reality, we expect the "id" to be badge number and the "name" to be badge name, once everything is hooked together. For now, it's dummy data.

On failure, returns
```
{"success":"false","message":"..."}
```