### PR TITLE
Do proper versioning of the frontend components

### DIFF
--- a/arisia-remote/app/arisia/controllers/FrontendController.scala
+++ b/arisia-remote/app/arisia/controllers/FrontendController.scala
@@ -20,5 +20,5 @@ class FrontendController(
   def index(): Action[AnyContent] = assets.at("/frontend/index.html")
 
   def assetOrDefault(resource: String): Action[AnyContent] =
-    if (resource.contains(".")) assets.at(s"/frontend/$resource") else index
+    if (resource.contains(".")) assets.versioned(s"/frontend/$resource") else index
 }


### PR DESCRIPTION
This should reduce unnecessary reloads, by adding ETags to all of the frontend components being proxied by the backend. With everything signed this way, the browser will version-check stuff before loading it, and only reload if the signature has changed.