### PR TITLE
Add "Infinite" Image Carousel.

### DIFF
--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.html
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.html
@@ -1,0 +1,30 @@
+<ngb-carousel #carousel class="hall-costumes-carousel" *ngIf="imageBuffer.length > 0"
+              [showNavigationArrows]="true" [showNavigationIndicators]="false" [pauseOnHover]="false" [pauseOnFocus]="false"
+              (slid)="handleSlidEvent($event)">
+  <ng-template ngbSlide *ngFor="let image of imageBuffer">
+    <div class="image-wrapper">
+      <img class="image" [src]="image.src" [alt]="image.caption">
+    </div>
+    <div class="carousel-caption">
+      <p>{{image.caption}}</p>
+    </div>
+  </ng-template>
+</ngb-carousel>
+
+<!-- Gradient overlay -->
+<div class="overlay"></div>
+
+<!-- Pause Button -->
+<div class="playpause" (click)="pause()" *ngIf="!paused">
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-pause-circle" viewBox="0 0 16 16">
+    <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+    <path fill-rule="evenodd" d="M5 6.25a1.25 1.25 0 1 1 2.5 0v3.5a1.25 1.25 0 1 1-2.5 0v-3.5zm3.5 0a1.25 1.25 0 1 1 2.5 0v3.5a1.25 1.25 0 1 1-2.5 0v-3.5z"/>
+  </svg>
+</div>
+<!-- Play Button -->
+<div class="playpause" (click)="play()" *ngIf="paused">
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-play-circle" viewBox="0 0 16 16">
+    <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+    <path fill-rule="evenodd" d="M6.271 5.055a.5.5 0 0 1 .52.038l3.5 2.5a.5.5 0 0 1 0 .814l-3.5 2.5A.5.5 0 0 1 6 10.5v-5a.5.5 0 0 1 .271-.445z"/>
+  </svg>
+</div>

--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.html
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.html
@@ -1,12 +1,13 @@
 <ngb-carousel #carousel class="hall-costumes-carousel" *ngIf="imageBuffer.length > 0"
-              [showNavigationArrows]="true" [showNavigationIndicators]="false" [pauseOnHover]="false" [pauseOnFocus]="false"
+              [showNavigationArrows]="true" [showNavigationIndicators]="false"
+              [pauseOnHover]="false" [pauseOnFocus]="false" [interval]="20000"
               (slid)="handleSlidEvent($event)">
   <ng-template ngbSlide *ngFor="let image of imageBuffer">
     <div class="image-wrapper">
       <img class="image" [src]="image.src" [alt]="image.caption">
     </div>
-    <div class="carousel-caption">
-      <p>{{image.caption}}</p>
+    <div class="carousel-caption hall-costume-caption">
+      {{image.caption}}
     </div>
   </ng-template>
 </ngb-carousel>

--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.scss
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.scss
@@ -24,10 +24,15 @@
     overflow: hidden;
 }
 
+.hall-costume-caption {
+    bottom: 1.5rem;
+    padding: 0;
+}
+
 .playpause {
     position: absolute;
 
-    bottom: 20px;
+    bottom: 1.5rem;
     right: 8px;
 
     height: 32px;
@@ -38,9 +43,9 @@
     z-index: 10;
     cursor: pointer;
 
-    opacity: 0.5;
+    opacity: 0.7;
     transition: opacity 0.15s ease;
 }
 .playpause:hover, .playpause:focus {
-    opacity: 0.9;
+    opacity: 1;
 }

--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.scss
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.scss
@@ -1,0 +1,47 @@
+.hall-costumes-carousel {
+    height: 100%;
+    width: 100%;
+}
+:host {
+    height: 100%;
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+}
+.overlay {
+    z-index: 5; // Underlying images are at 1. Text and Pause button are at 10.
+    position: absolute;
+    bottom: 0;
+
+    height: 5rem;
+    width: 100%;
+
+    background-image: linear-gradient(rgba(0,0,0,0),rgba(0, 0, 0, 0.5));
+}
+
+.image-wrapper {
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+}
+
+.playpause {
+    position: absolute;
+
+    bottom: 20px;
+    right: 8px;
+
+    height: 32px;
+    width: 32px;
+    padding: 6px;
+
+    color: white;
+    z-index: 10;
+    cursor: pointer;
+
+    opacity: 0.5;
+    transition: opacity 0.15s ease;
+}
+.playpause:hover, .playpause:focus {
+    opacity: 0.9;
+}

--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.scss
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.scss
@@ -13,15 +13,14 @@
     position: absolute;
     bottom: 0;
 
-    height: 5rem;
+    height: 10rem;
     width: 100%;
 
     background-image: linear-gradient(rgba(0,0,0,0),rgba(0, 0, 0, 0.5));
 }
 
 .image-wrapper {
-    height: 100%;
-    width: 100%;
+    height: 29em;
     overflow: hidden;
 }
 

--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.spec.ts
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HallCostumesComponent } from './hall-costumes.component';
+
+describe('HallCostumesComponent', () => {
+  let component: HallCostumesComponent;
+  let fixture: ComponentFixture<HallCostumesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HallCostumesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HallCostumesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.ts
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.ts
@@ -35,8 +35,8 @@ export class HallCostumesComponent implements OnInit {
   constructor() { }
 
   ngOnInit(): void {
-    this.images = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20].map(
-      (n) => ({src: `https://picsum.photos/id/${n}/900/500`, caption: `Image number ${n}`}));
+    this.images = [{src: 'https://coolbackgrounds.io/images/backgrounds/white/pure-white-background-85a2a7fd.jpg', caption: 'This Image Is Totally White'}].concat([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20].map(
+    (n) => ({src: `https://picsum.photos/id/${n}/900/500`, caption: `Image number ${n}`})));
     this.updateImageBufferSize();
     this.forceUpdateImageBuffer();
   }

--- a/frontend/src/app/map/hall-costumes/hall-costumes.component.ts
+++ b/frontend/src/app/map/hall-costumes/hall-costumes.component.ts
@@ -1,0 +1,118 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { NgbCarousel, NgbSlideEvent } from '@ng-bootstrap/ng-bootstrap';
+
+interface Image {
+  src: string;
+  caption: string;
+};
+
+function moduloDecrement(value: number, divisor: number): number {
+  return (value + divisor - 1) % divisor;
+}
+
+function moduloIncrement(value: number, divisor: number): number {
+  return (value + 1) % divisor;
+}
+
+@Component({
+  selector: 'app-hall-costumes',
+  templateUrl: './hall-costumes.component.html',
+  styleUrls: ['./hall-costumes.component.scss']
+
+})
+export class HallCostumesComponent implements OnInit {
+  images: Image[] = [];
+  currentImage: number = 0;
+
+  imageBuffer: Image[] = [];
+  currentImageBuffer: number[] = [];
+  currentFrame: number = 0;
+
+  paused: boolean = false;
+
+  @ViewChild(NgbCarousel) carousel!: NgbCarousel;
+
+  constructor() { }
+
+  ngOnInit(): void {
+    this.images = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20].map(
+      (n) => ({src: `https://picsum.photos/id/${n}/900/500`, caption: `Image number ${n}`}));
+    this.updateImageBufferSize();
+    this.forceUpdateImageBuffer();
+  }
+
+  play(): void {
+    this.carousel.next();
+    this.carousel.cycle();
+    this.paused = false;
+  }
+
+  pause(): void {
+    this.carousel.pause();
+    this.paused = true;
+  }
+
+  handleSlidEvent(event: NgbSlideEvent) {
+    let backward = false;
+    if (event.direction !== 'right') {
+      // Go forward
+      this.currentFrame = moduloIncrement(this.currentFrame, this.imageBuffer.length);
+      this.currentImage = moduloIncrement(this.currentImage, this.images.length);
+    } else {
+      // Go backward
+      this.currentFrame = moduloDecrement(this.currentFrame, this.imageBuffer.length);
+      this.currentImage = moduloDecrement(this.currentImage, this.images.length);
+    }
+    this.updateImageBuffer();
+    this.paused = event.paused;
+  }
+
+  updateImageBufferSize(): void {
+    this.imageBuffer.length = Math.min(this.images.length, 3);
+    if (this.currentImage > this.images.length) {
+      this.currentImage = 0;
+    }
+    if (this.currentFrame > this.imageBuffer.length) {
+      this.currentFrame = 0;
+    }
+  }
+
+  updateImageBuffer(): void {
+    if (this.imageBuffer.length > 0) {
+      this.updateImage(this.currentFrame, this.currentImage);
+    }
+    if (this.imageBuffer.length > 1) {
+      this.updateImage(moduloIncrement(this.currentFrame, this.imageBuffer.length),
+                       moduloIncrement(this.currentImage, this.images.length))
+    }
+    if (this.imageBuffer.length > 2) {
+      this.updateImage(moduloDecrement(this.currentFrame, this.imageBuffer.length),
+                       moduloDecrement(this.currentImage, this.images.length))
+    }
+  }
+
+  updateImage(frame: number, image: number): void {
+    if (this.currentImageBuffer[frame] !== image) {
+      this.forceUpdateImage(frame, image);
+    }
+  }
+
+  forceUpdateImageBuffer(): void {
+    if (this.imageBuffer.length > 0) {
+      this.forceUpdateImage(this.currentFrame, this.currentImage);
+    }
+    if (this.imageBuffer.length > 1) {
+      this.forceUpdateImage(moduloIncrement(this.currentFrame, this.imageBuffer.length),
+                            moduloIncrement(this.currentImage, this.images.length))
+    }
+    if (this.imageBuffer.length > 2) {
+      this.forceUpdateImage(moduloDecrement(this.currentFrame, this.imageBuffer.length),
+                            moduloDecrement(this.currentImage, this.images.length))
+    }
+  }
+
+  forceUpdateImage(frame: number, image: number): void {
+    this.currentImageBuffer[frame] = image;
+    this.imageBuffer[frame] = this.images[image];
+  }
+}

--- a/frontend/src/app/map/map.component.html
+++ b/frontend/src/app/map/map.component.html
@@ -25,8 +25,8 @@
         </div>
     </div>
     <div class="col-6 col-md-3">
-        <div class="row">
-            <app-link height=3 color="rgba(56, 167, 202, 0.25)">Costume Feed</app-link>
+        <div class="row" style="height: 29rem">
+          <app-hall-costumes>Costume Feed</app-hall-costumes>
         </div>
     </div>
     <div class="col-6 col-md-3">

--- a/frontend/src/app/map/map.module.ts
+++ b/frontend/src/app/map/map.module.ts
@@ -3,15 +3,18 @@ import { CommonModule } from '@angular/common';
 
 import { MapRoutingModule } from './map-routing.module';
 import { MapComponent } from './map.component';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { SharedModule } from '@app/_components';
 import { FeaturedEventsComponent } from './featured-events/featured-events.component';
+import { HallCostumesComponent } from './hall-costumes/hall-costumes.component';
 
 
 @NgModule({
-  declarations: [MapComponent, FeaturedEventsComponent],
+  declarations: [MapComponent, FeaturedEventsComponent, HallCostumesComponent],
   imports: [
     CommonModule,
     MapRoutingModule,
+    NgbModule,
     SharedModule
   ]
 })


### PR DESCRIPTION
This carousel works by having an arbitrarily large list of images. It
has a buffer of 3 images and creates a carousel with those three
images. Based on the current image and the current frame of the
carousel, it updates the buffer so that the images on either side of
the current image will be correct.

This allows us to have an arbitrarily large set of images while only
having 3 sets of DOM built at any time. It also only loads the images
when they're the next one to be shown. We can update the size of the
buffer if we want to preload more images. We could even have more
images preloaded ahead than behind.

We can also have a trigger when we're getting close to the currently
loaded set of images to ask for more images. I'm imagining a backend
that returns images in chunks. When we're within 5 images or so of the
end of the current set of images, we request a new chunk.  We can have
the frontend pick a seed and have the backend run a permutations
algorithm based on that seed, thus guaranteeing that a user won't see
the same image until they've seen all of them, but they'll be in a
different order each time.

The UI has a gradient overlay at the bottom so that the caption will
be readable, even if the image is white there. It has a pause button
in the lower right corner to allow the user to pause the images if
they wish to. The forward and back buttons will continue to work.

The component claims to support swipes on a touch device, but I
haven't been able to get it to work on chrome emulation.

Screenshot
![carousel-paused](https://user-images.githubusercontent.com/283548/102308844-84471680-3f35-11eb-865b-d38c9704a08e.png)
