### PR TITLE
Move the path for backend assets

### DIFF
--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -9,5 +9,9 @@ play.filters.cors.allowedOrigins =  null
 
 db.default.driver = org.postgresql.Driver
 
+# We need to move the admin stuff to a non-default position, because the frontend needs /assets for their
+# stuff:
+play.assets.urlPrefix = "/admin/assets"
+
 # All secrets MUST go into the .gitignore'd secrets.conf file. See secrets.conf.template for details.
 include "secrets.conf"

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -36,12 +36,12 @@ GET     /admin/                      arisia.controllers.AdminController.home()
 GET     /admin/manageAdmins          arisia.controllers.AdminController.manageAdmins()
 POST    /admin/manageAdmins          arisia.controllers.AdminController.addAdmin()
 DELETE  /admin/manageAdmins/:name    arisia.controllers.AdminController.removeAdmin(name)
+# Note the non-standard path, which is configured in application.conf, so that frontend
+# can own /assets
+GET     /admin/assets/*file          controllers.Assets.versioned(path="/public", file: Asset)
 
 # Zambia emulator, providing test data
 GET     /test/fakeschedule           arisia.controllers.FakeZambiaController.getSchedule()
-
-# Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file                controllers.Assets.versioned(path="/public", file: Asset)
 
 # Fetch frontend assets
 GET     /*file                       arisia.controllers.FrontendController.assetOrDefault(file)


### PR DESCRIPTION
Currently the frontend and backend assets both need `/assets`, which is causing problems. This moves the Admin UI assets to `/admin/assets`