### PR TITLE
Add early access flag

### DIFF
--- a/arisia-remote/app/arisia/admin/AdminService.scala
+++ b/arisia-remote/app/arisia/admin/AdminService.scala
@@ -1,10 +1,9 @@
 package arisia.admin
 
 import arisia.db.DBService
-import arisia.models.{LoginName, LoginId}
+import arisia.models.LoginId
 import doobie._
 import doobie.implicits._
-import doobie.util.fragment
 import play.api.Logging
 
 import scala.concurrent.{Future, ExecutionContext}
@@ -27,6 +26,10 @@ trait AdminService {
    * Take away this person's Admin rights.
    */
   def removeAdmin(name: LoginId): Future[Int]
+
+  def getEarlyAccess(): Future[List[LoginId]]
+  def addEarlyAccess(id: LoginId): Future[Int]
+  def removeEarlyAccess(id: LoginId): Future[Int]
 }
 
 class AdminServiceImpl(
@@ -82,8 +85,18 @@ class AdminServiceImpl(
     }
   }
 
+  // TODO: in a perfect world, we would do something more typeclass-based, to remove the boilerplate of all these
+  // distinct calls. But I don't have time right now to work out all the interlocking classes needed to make it
+  // properly strongly-typed all the way down.
+
   lazy val admins = new PermissionColumn("admin")
   def getAdmins(): Future[List[LoginId]] = admins.getMembers()
   def addAdmin(id: LoginId): Future[Int] = admins.addMember(id)
   def removeAdmin(id: LoginId): Future[Int] = admins.removeMember(id)
+
+  lazy val earlyAccess = new PermissionColumn("early_access")
+  def getEarlyAccess(): Future[List[LoginId]] = earlyAccess.getMembers()
+  def addEarlyAccess(id: LoginId): Future[Int] = earlyAccess.addMember(id)
+  def removeEarlyAccess(id: LoginId): Future[Int] = earlyAccess.removeMember(id)
+
 }

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -55,6 +55,9 @@ class AdminController (
    */
   def adminsOnly(f: AdminInfo => Result): EssentialAction = adminsOnlyAsync(info => Future.successful(f(info)))
 
+  /**
+   * Enhanced version of adminsOnlyAsync, for stuff that only super-admins can do.
+   */
   def superAdminsOnlyAsync(f: AdminInfo => Future[Result]): EssentialAction = adminsOnlyAsync { info =>
     if (info.permissions.superAdmin) {
       f(info)

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -66,7 +66,7 @@ class AdminController (
     Ok(arisia.views.html.adminHome(info.permissions))
   }
 
-  val newAdminForm = Form(
+  val usernameForm = Form(
     mapping(
       "username" -> nonEmptyText
     )(LoginId.apply)(LoginId.unapply)
@@ -75,7 +75,7 @@ class AdminController (
   private def showManageAdmins()(implicit request: Request[AnyContent]) = {
     adminService.getAdmins().map { admins =>
       val sorted = admins.sortBy(_.v)
-      Ok(arisia.views.html.manageAdmins(sorted, newAdminForm.fill(LoginId(""))))
+      Ok(arisia.views.html.manageAdmins(sorted, usernameForm.fill(LoginId(""))))
     }
   }
 
@@ -87,7 +87,7 @@ class AdminController (
   def addAdmin(): EssentialAction = superAdminsOnlyAsync { info =>
     implicit val request = info.request
 
-    newAdminForm.bindFromRequest().fold(
+    usernameForm.bindFromRequest().fold(
       formWithErrors => {
         // TODO: actually display the error!
         Future.successful(Redirect(routes.AdminController.manageAdmins()))

--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -39,13 +39,13 @@ class LoginController (
         case Some(user) => {
           loginService.getPermissions(user.id).map { permissions =>
             val allowed =
-//              if (earlyAccessOnly) {
-//                // We're in early-access mode, so the general public is *not* allowed in
-//                // In a dev environment, add your login to `arisia.allow.logins` in order to permit your own login:
-//                permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id.v)
-//              } else {
+              if (earlyAccessOnly) {
+                // We're in early-access mode, so the general public is *not* allowed in
+                // In a dev environment, add your login to `arisia.allow.logins` in order to permit your own login:
+                permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id.v)
+              } else {
                 true
-//              }
+              }
 
             if (allowed) {
               val json = Json.toJson(user)

--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -39,12 +39,13 @@ class LoginController (
         case Some(user) => {
           loginService.getPermissions(user.id).map { permissions =>
             val allowed =
-              if (earlyAccessOnly)
-              // We're in early-access mode, so the general public is *not* allowed in
-              // In a dev environment, add your login to `arisia.allow.logins` in order to permit your own login:
-              permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id.v)
-                else
+//              if (earlyAccessOnly) {
+//                // We're in early-access mode, so the general public is *not* allowed in
+//                // In a dev environment, add your login to `arisia.allow.logins` in order to permit your own login:
+//                permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id.v)
+//              } else {
                 true
+//              }
 
             if (allowed) {
               val json = Json.toJson(user)

--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -2,6 +2,7 @@ package arisia.controllers
 
 import arisia.auth.LoginService
 import arisia.models.{LoginRequest, LoginUser}
+import play.api.Configuration
 import play.api.http._
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -10,6 +11,7 @@ import scala.concurrent.{Future, ExecutionContext}
 
 class LoginController (
   val controllerComponents: ControllerComponents,
+  config: Configuration,
   loginService: LoginService
 )(
   implicit ec: ExecutionContext
@@ -17,6 +19,8 @@ class LoginController (
   extends BaseController
 {
   import LoginController._
+
+  lazy val earlyAccessOnly: Boolean = config.get[Boolean]("arisia.early.access.only")
 
   def me(): EssentialAction = Action { implicit request =>
     request.session.get(userKey) match {
@@ -28,15 +32,28 @@ class LoginController (
 
   def login(): EssentialAction = Action.async(controllerComponents.parsers.tolerantJson[LoginRequest]) { implicit request =>
     val req = request.body
-    loginService.checkLogin(req.id, req.password).map {
+    loginService.checkLogin(req.id, req.password).flatMap {
       _ match {
         case Some(user) => {
-          val json = Json.toJson(user)
-          val jsStr = Json.stringify(json)
-          Ok(jsStr).withSession(userKey -> jsStr).as(JSON)
+          loginService.getPermissions(user.id).map { permissions =>
+            val allowed =
+              if (earlyAccessOnly)
+              // We're in early-access mode, so the general public is *not* allowed in:
+              permissions.superAdmin || permissions.admin || permissions.earlyAccess
+                else
+                true
+
+            if (allowed) {
+              val json = Json.toJson(user)
+              val jsStr = Json.stringify(json)
+              Ok(jsStr).withSession(userKey -> jsStr).as(JSON)
+            } else {
+              Unauthorized("""{"success":"false", "message":"Sorry - you aren't allowed into this site yet. Talk to Remote if you believe you should have access."}""")
+            }
+          }
         }
         case None => {
-          Unauthorized("""{"success":"false", "message":"Put a real error message here"}""")
+          Future.successful(Unauthorized("""{"success":"false", "message":"Sorry - that isn't a valid username and password"}"""))
         }
       }
     }

--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -1,7 +1,7 @@
 package arisia.controllers
 
 import arisia.auth.LoginService
-import arisia.models.{LoginRequest, LoginUser}
+import arisia.models.{LoginRequest, LoginUser, LoginId}
 import play.api.Configuration
 import play.api.http._
 import play.api.libs.json.Json
@@ -22,7 +22,8 @@ class LoginController (
 
   lazy val earlyAccessOnly: Boolean = config.get[Boolean]("arisia.early.access.only")
 
-  lazy val allowedLogins: Seq[String] = config.get[Seq[String]]("arisia.allow.logins")
+  lazy val allowedLogins: Seq[LoginId] =
+    config.get[Seq[String]]("arisia.allow.logins").map(LoginId(_))
 
   def me(): EssentialAction = Action { implicit request =>
     request.session.get(userKey) match {
@@ -42,7 +43,7 @@ class LoginController (
               if (earlyAccessOnly) {
                 // We're in early-access mode, so the general public is *not* allowed in
                 // In a dev environment, add your login to `arisia.allow.logins` in order to permit your own login:
-                permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id.v)
+                permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id)
               } else {
                 true
               }

--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -22,6 +22,8 @@ class LoginController (
 
   lazy val earlyAccessOnly: Boolean = config.get[Boolean]("arisia.early.access.only")
 
+  lazy val allowedLogins: Seq[String] = config.get[Seq[String]]("arisia.allow.logins")
+
   def me(): EssentialAction = Action { implicit request =>
     request.session.get(userKey) match {
       case Some(jsonStr) => Ok(jsonStr)
@@ -38,8 +40,9 @@ class LoginController (
           loginService.getPermissions(user.id).map { permissions =>
             val allowed =
               if (earlyAccessOnly)
-              // We're in early-access mode, so the general public is *not* allowed in:
-              permissions.superAdmin || permissions.admin || permissions.earlyAccess
+              // We're in early-access mode, so the general public is *not* allowed in
+              // In a dev environment, add your login to `arisia.allow.logins` in order to permit your own login:
+              permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id.v)
                 else
                 true
 

--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -6,4 +6,6 @@
   @if(permissions.superAdmin) {
     <h2><a href="/admin/manageAdmins">Manage Admins</a></h2>
   }
+
+<h2><a href="/admin/manageEarlyAccess">Manage Early Access</a></h2>
 }

--- a/arisia-remote/app/arisia/views/manageAdmins.scala.html
+++ b/arisia-remote/app/arisia/views/manageAdmins.scala.html
@@ -2,46 +2,13 @@
 
 @import helper._
 
-@main("Arisia Admin - Manage Admins") {
-  <h1>Manage Admins</h1>
-
-  <p>The currently-known Admins are:</p>
-
-  <ul>
-    @for(admin <- admins) {
-      <li>@{admin.v}
-        <button type="button" class="btn btn-sm btn-danger" data-toggle="modal" data-target="#removeModal" data-confirmid="@{admin.v}">Remove</button>
-      </li>
-    }
-  </ul>
-
-  <p>Add another Admin:</p>
-
+@managePermissionTemplate(
+  admins,
+  newAdminForm,
+  "Admin",
+  "/admin/manageAdmins/"
+) {
   @helper.form(action = arisia.controllers.routes.AdminController.addAdmin()) {
     @helper.inputText(newAdminForm("username"))
   }
-
-  @*
-   * Confirm dialog for removing an Admin.
-   *@
-  <div class="modal fade confirmModal" id="removeModal" tabindex="-1" role="dialog" aria-labelledby="confirmRemoveLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="confirmRemoveLabel">Confirm Remove Admin</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <p><strong>Please confirm: remove Admin privileges from <span class="modal-body-id"></span>?</strong></p>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-danger confirmed-button" id="remove-button"
-                  data-baseurl="/admin/manageAdmins/">Remove Admin</button>
-        </div>
-      </div>
-    </div>
-  </div>
 }

--- a/arisia-remote/app/arisia/views/manageAdmins.scala.html
+++ b/arisia-remote/app/arisia/views/manageAdmins.scala.html
@@ -38,7 +38,8 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-danger confirmed-button" id="remove-admin-button">Remove Admin</button>
+          <button type="button" class="btn btn-danger confirmed-button" id="remove-button"
+                  data-baseurl="/admin/manageAdmins/">Remove Admin</button>
         </div>
       </div>
     </div>

--- a/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
+++ b/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
@@ -1,0 +1,46 @@
+@(people: List[arisia.models.LoginId], newPersonForm: Form[arisia.models.LoginId])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
+
+@import helper._
+
+@main("Arisia Admin - Manage Early Access") {
+  <h1>Manage Early Access</h1>
+
+  <p>The people with Early Access (besides Admins) are:</p>
+
+  <ul>
+    @for(person <- people) {
+      <li>@{person.v}
+        <button type="button" class="btn btn-sm btn-danger" data-toggle="modal" data-target="#removeModal" data-confirmid="@{person.v}">Remove</button>
+      </li>
+    }
+  </ul>
+
+  <p>Give another person Early Access:</p>
+
+  @helper.form(action = arisia.controllers.routes.AdminController.addEarlyAccess()) {
+    @helper.inputText(newPersonForm("username"))
+  }
+
+  @*
+   * Confirm dialog for removing this permission.
+   *@
+  <div class="modal fade confirmModal" id="removeModal" tabindex="-1" role="dialog" aria-labelledby="confirmRemoveLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmRemoveLabel">Confirm Remove Early Access</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p><strong>Please confirm: remove Early Access privileges from <span class="modal-body-id"></span>?</strong></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-danger confirmed-button" id="remove-early-access-button">Remove Early Access</button>
+        </div>
+      </div>
+    </div>
+  </div>
+}

--- a/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
+++ b/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
@@ -2,46 +2,13 @@
 
 @import helper._
 
-@main("Arisia Admin - Manage Early Access") {
-  <h1>Manage Early Access</h1>
-
-  <p>The people with Early Access (besides Admins) are:</p>
-
-  <ul>
-    @for(person <- people) {
-      <li>@{person.v}
-        <button type="button" class="btn btn-sm btn-danger" data-toggle="modal" data-target="#removeModal" data-confirmid="@{person.v}">Remove</button>
-      </li>
-    }
-  </ul>
-
-  <p>Give another person Early Access:</p>
-
+@managePermissionTemplate(
+  people,
+  newPersonForm,
+  "Early Access",
+  "/admin/manageEarlyAccess/"
+) {
   @helper.form(action = arisia.controllers.routes.AdminController.addEarlyAccess()) {
     @helper.inputText(newPersonForm("username"))
   }
-
-  @*
-   * Confirm dialog for removing this permission.
-   *@
-  <div class="modal fade confirmModal" id="removeModal" tabindex="-1" role="dialog" aria-labelledby="confirmRemoveLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="confirmRemoveLabel">Confirm Remove Early Access</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <p><strong>Please confirm: remove Early Access privileges from <span class="modal-body-id"></span>?</strong></p>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-danger confirmed-button" id="remove-button"
-                  data-baseurl="/admin/manageEarlyAccess/">Remove Early Access</button>
-        </div>
-      </div>
-    </div>
-  </div>
 }

--- a/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
+++ b/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
@@ -38,7 +38,8 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-danger confirmed-button" id="remove-early-access-button">Remove Early Access</button>
+          <button type="button" class="btn btn-danger confirmed-button" id="remove-button"
+                  data-baseurl="/admin/manageEarlyAccess/">Remove Early Access</button>
         </div>
       </div>
     </div>

--- a/arisia-remote/app/arisia/views/managePermissionTemplate.scala.html
+++ b/arisia-remote/app/arisia/views/managePermissionTemplate.scala.html
@@ -1,0 +1,54 @@
+@(
+  people: List[arisia.models.LoginId],
+  newPersonForm: Form[arisia.models.LoginId],
+  permName: String,
+  baseUrl: String
+)(
+  addForm: Html
+)(
+  implicit request: RequestHeader, messagesProvider: MessagesProvider
+)
+
+@import helper._
+
+@main(s"Arisia Admin - Manage $permName") {
+  <h1>Manage @permName</h1>
+
+  <p>The people with @permName are:</p>
+
+  <ul>
+    @for(person <- people) {
+      <li>@{person.v}
+        <button type="button" class="btn btn-sm btn-danger" data-toggle="modal" data-target="#removeModal" data-confirmid="@{person.v}">Remove</button>
+      </li>
+    }
+  </ul>
+
+  <p>Give another person @permName:</p>
+
+  @addForm
+
+  @*
+   * Confirm dialog for removing this permission.
+   *@
+  <div class="modal fade confirmModal" id="removeModal" tabindex="-1" role="dialog" aria-labelledby="confirmRemoveLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmRemoveLabel">Confirm Remove @permName</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p><strong>Please confirm: remove @permName privileges from <span class="modal-body-id"></span>?</strong></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-danger confirmed-button" id="remove-button"
+                  data-baseurl="@baseUrl">Remove @permName</button>
+        </div>
+      </div>
+    </div>
+  </div>
+}

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -13,5 +13,10 @@ db.default.driver = org.postgresql.Driver
 # stuff:
 play.assets.urlPrefix = "/admin/assets"
 
+arisia {
+  # Set this to false to open the doors to the public:
+  early.access.only = true
+}
+
 # All secrets MUST go into the .gitignore'd secrets.conf file. See secrets.conf.template for details.
 include "secrets.conf"

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -36,6 +36,9 @@ GET     /admin/                      arisia.controllers.AdminController.home()
 GET     /admin/manageAdmins          arisia.controllers.AdminController.manageAdmins()
 POST    /admin/manageAdmins          arisia.controllers.AdminController.addAdmin()
 DELETE  /admin/manageAdmins/:name    arisia.controllers.AdminController.removeAdmin(name)
+GET     /admin/manageEarlyAccess          arisia.controllers.AdminController.manageEarlyAccess()
+POST    /admin/manageEarlyAccess          arisia.controllers.AdminController.addEarlyAccess()
+DELETE  /admin/manageEarlyAccess/:name    arisia.controllers.AdminController.removeEarlyAccess(name)
 # Note the non-standard path, which is configured in application.conf, so that frontend
 # can own /assets
 GET     /admin/assets/*file          controllers.Assets.versioned(path="/public", file: Asset)

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -11,3 +11,6 @@ play.http.secret.key="[long string of characters here]"
 #
 # This should point to the site database, which should exist but otherwise starts out empty.
 db.default.url = "<JDBC URL for Postgres DB>"
+
+# Put your own login here in dev environments, to allow access for yourself:
+arisia.allow.logins = []

--- a/arisia-remote/public/javascripts/main.js
+++ b/arisia-remote/public/javascripts/main.js
@@ -8,20 +8,6 @@ $('.confirmModal').on('show.bs.modal', function (event) {
   modal.find('.confirmed-button').data('who', recipient)
 })
 
-$('#remove-admin-button').click(function(event) {
-  var button = $('#remove-admin-button'); // Button that triggered the modal
-  var who = button.data('who');
-  console.log("The person we are removing is " + who);
-  $.ajax({
-    url: '/admin/manageAdmins/' + who,
-    type: 'DELETE',
-    complete: function() {
-      var url = window.location.href;
-      window.location.href = url;
-    }
-  });
-});
-
 $('#remove-button').click(function(event) {
   var button = $('#remove-button'); // Button that triggered the modal
   var who = button.data('who');

--- a/arisia-remote/public/javascripts/main.js
+++ b/arisia-remote/public/javascripts/main.js
@@ -22,12 +22,13 @@ $('#remove-admin-button').click(function(event) {
   });
 });
 
-$('#remove-early-access-button').click(function(event) {
-  var button = $('#remove-early-access-button'); // Button that triggered the modal
+$('#remove-button').click(function(event) {
+  var button = $('#remove-button'); // Button that triggered the modal
   var who = button.data('who');
+  var baseUrl = button.data('baseurl')
   console.log("The person we are removing is " + who);
   $.ajax({
-    url: '/admin/manageEarlyAccess/' + who,
+    url: baseUrl + who,
     type: 'DELETE',
     complete: function() {
       var url = window.location.href;

--- a/arisia-remote/public/javascripts/main.js
+++ b/arisia-remote/public/javascripts/main.js
@@ -21,3 +21,17 @@ $('#remove-admin-button').click(function(event) {
     }
   });
 });
+
+$('#remove-early-access-button').click(function(event) {
+  var button = $('#remove-early-access-button'); // Button that triggered the modal
+  var who = button.data('who');
+  console.log("The person we are removing is " + who);
+  $.ajax({
+    url: '/admin/manageEarlyAccess/' + who,
+    type: 'DELETE',
+    complete: function() {
+      var url = window.location.href;
+      window.location.href = url;
+    }
+  });
+});


### PR DESCRIPTION
This introduces a new configuration flag, `arisia.early.access.only`, which currently defaults to true.  (And which we expect will remain true until somewhere in the last few days before the con starts.)  So long as this is true, only people who explicitly have a new Early Access flag, or who have Admin status, will be allowed to log into the site.

**Important:** this also adds an `arisia.allow.logins` array of strings to the `secrets.conf.template` file.  In your development environment, you should add your own username (that is, your login username from Convention Master, which you used to register for the con) to this array in your own local copy of `secrets.conf`.  That will allow you to log into your own environment.  (Otherwise you'd have to go in and manually enter an entry into your local Postgres DB to give yourself permission.)

This also introduces a new UI for giving this flag to people.  Like the Admin page before it, this is *ridiculously* crude and simplistic, but should suffice for now.  If we find ourselves with time to improve the Admin interface we can do so, but for now, we'll deal with dumb-and-simple.

Much of the actual code changes here are around taking the Admin and Early Access management systems and lifting generic machinery out, to keep the boilerplate down.  We expect to see at least several more of these Permissions, and we will be much happier if adding a new one is mostly reusing existing systems.

As a side-effect, the code now demonstrates how to create reusable SQL fragments in Doobie.