### PR TITLE
Rework the code to expect the schedule as JSON instead of JSONP

### DIFF
--- a/arisia-remote/app/arisia/controllers/FakeZambiaController.scala
+++ b/arisia-remote/app/arisia/controllers/FakeZambiaController.scala
@@ -1,6 +1,8 @@
 package arisia.controllers
 
+import arisia.models.Schedule
 import better.files.Resource
+import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
 
 import scala.concurrent.ExecutionContext
@@ -22,14 +24,20 @@ class FakeZambiaController (
   var _theSchedule: Option[String] = None
 
   def getSchedule(): EssentialAction = Action { implicit request =>
-    val s = _theSchedule match {
+    val s: String = _theSchedule match {
       case Some(schedule) => schedule
       case None => {
+        // Our test data is the 2014 schedule in JSONP format. Translate that into JSON, which is what we now
+        // expect.
         // EVIL: please note that the following line is *not* okay in real code, because it blocks the current
         // thread. It's legit here only because this is test code that won't run in the real site. If you
         // need to do file IO for real, let's talk about ways to do that more appropriately. (There are better
         // options, they just require a bit more code.)
-        _theSchedule = Some(Resource.getAsString("konopastest.jsonp"))
+        val jsonp = Resource.getAsString("konopastest.jsonp")
+        val schedule = Schedule.parseKonOpas(jsonp)
+        // TODO: massage the timing of the schedule so that it is happening today
+        // TODO: massage the rooms in the schedule to match our actual rooms, and reduce to fewer of them
+        _theSchedule = Some(Json.toJson(schedule).toString())
         _theSchedule.get
       }
     }

--- a/arisia-remote/app/arisia/schedule/ScheduleService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleService.scala
@@ -7,6 +7,7 @@ import arisia.models.Schedule
 import doobie._
 import doobie.implicits._
 import play.api.Logging
+import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{Future, ExecutionContext}
@@ -30,32 +31,35 @@ class ScheduleServiceImpl(
   implicit ec: ExecutionContext
 ) extends ScheduleService with Logging {
 
-  case class ScheduleCache(jsonp: String) {
-    lazy val parsed = Schedule.parseKonOpas(jsonp)
+  case class ScheduleCache(jsonStr: String) {
+    lazy val parsed: Schedule = {
+      // TODO: make this cope with failure!
+      Json.parse(jsonStr).as[Schedule]
+    }
   }
 
   // The currently-cached schedule, to serve out whenever the frontend needs it.
   // The initial value is just there so that we have something valid while we wait to load the initial value
   // from the DB
   val _theSchedule: AtomicReference[ScheduleCache] =
-    new AtomicReference(ScheduleCache("var program = []; var people = []"))
+    new AtomicReference(ScheduleCache("{\"program\":[], \"people\": []}"))
 
-  final val scheduleRowName: String = "scheduleJsonp"
+  final val scheduleRowName: String = "scheduleJson"
 
   val loadInitialScheduleQuery: ConnectionIO[String] =
     sql"SELECT value from text_files WHERE name = $scheduleRowName"
     .query[String]
     .unique
 
-  def updateScheduleStatement(scheduleJsonp: String): ConnectionIO[Int] =
-    sql"UPDATE text_files set value = $scheduleJsonp where name = $scheduleRowName"
+  def updateScheduleStatement(scheduleJson: String): ConnectionIO[Int] =
+    sql"UPDATE text_files set value = $scheduleJson where name = $scheduleRowName"
     .update
     .run
 
   // At boot time, load the last-known version of the schedule:
-  dbService.run(loadInitialScheduleQuery).map { jsonp =>
-    logger.info(s"Schedule loaded from DB -- size ${jsonp.length}")
-    _theSchedule.set(ScheduleCache(jsonp))
+  dbService.run(loadInitialScheduleQuery).map { json =>
+    logger.info(s"Schedule loaded from DB -- size ${json.length}")
+    _theSchedule.set(ScheduleCache(json))
   }
 
   /**
@@ -69,22 +73,22 @@ class ScheduleServiceImpl(
     ws.url("http://localhost:9000/test/fakeschedule")
       .get()
       .map { response =>
-        val jsonp = response.body
-        if (jsonp == _theSchedule.get.jsonp) {
+        val json = response.body
+        if (json == _theSchedule.get.jsonStr) {
           logger.info(s"Refresh -- schedule hasn't changed")
         } else {
-          logger.info(s"Refreshed the schedule from Zambia -- size ${jsonp.length}")
+          logger.info(s"Refreshed the schedule from Zambia -- size ${json.length}")
           // TODO: don't actually set the cache until we validate that the jsonp validates:
-          val cacheable = ScheduleCache(jsonp)
+          val cacheable = ScheduleCache(json)
           try {
             // For the moment, this can throw Exceptions.
             // TODO: make this pathway non-Exception-centric.
             val parsed = cacheable.parsed
             // Save it in the DB:
-            dbService.run(updateScheduleStatement(jsonp)).map { _ =>
+            dbService.run(updateScheduleStatement(json)).map { _ =>
               logger.info(s"Saved new Schedule in the database")
               // Once that's done, cache it:
-              _theSchedule.set(ScheduleCache(jsonp))
+              _theSchedule.set(ScheduleCache(json))
             }
           } catch {
             case ex: Exception => {

--- a/arisia-remote/conf/evolutions/default/3.sql
+++ b/arisia-remote/conf/evolutions/default/3.sql
@@ -1,0 +1,8 @@
+-- !Ups
+
+-- The format we expect from Zambia has changed from JSONP to JSON, so adjust accordingly
+-- Note that this is a new scheduleJson row, which supercedes the old scheduleJsonp one
+
+INSERT INTO text_files VALUES ('scheduleJson', '{"program":[], "people": []}');
+
+-- !Downs


### PR DESCRIPTION
Gail got the schedule exporter stood up in Zambia, and changed its export format since we prefer JSON. So this adjusts at our end.

For the moment, I'm still using the 2014 JSONP schedule for testing; that will likely get changed sometime in the near future, as the 2021 Zambia schedule gets into a state that works for us.