### PR TITLE
Adjust the dates in the Schedule to be "now"

### DIFF
--- a/arisia-remote/app/arisia/controllers/FakeZambiaController.scala
+++ b/arisia-remote/app/arisia/controllers/FakeZambiaController.scala
@@ -1,7 +1,10 @@
 package arisia.controllers
 
-import arisia.models.Schedule
+import java.time.{Period, LocalDate}
+
+import arisia.models.{ProgramItemDate, Schedule}
 import better.files.Resource
+import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
 
@@ -19,12 +22,35 @@ class FakeZambiaController (
 )(
   implicit ec: ExecutionContext
 )
-  extends BaseController
+  extends BaseController with Logging
 {
-  var _theSchedule: Option[String] = None
+  case class AdjustedSchedule(original: Schedule) {
+    /**
+     * We are going to adjust the schedule so that everything that happened on the Saturday of Arisia 2014 is "today".
+     */
+    val originalSaturday: LocalDate = LocalDate.of(2014, 1, 18)
+
+    lazy val today: LocalDate = LocalDate.now()
+    lazy val adjusted: Schedule = {
+      // We are shifting everything by this period:
+      val adjustment: Period = originalSaturday.until(today)
+      logger.info(s"Adjusting the schedule forward by $adjustment")
+      val adjustedItems = original.program.map { item =>
+        item.copy(date = item.date.map(date => ProgramItemDate(date.d.plus(adjustment))))
+      }
+      original.copy(program = adjustedItems)
+    }
+    lazy val stringified = Json.toJson(adjusted).toString()
+  }
+
+  // EVIL: note that we're using plain old vars here in this test-only code. Please refrain from using them in
+  // real code -- they risk all sorts of thread-unsafety problems that we are trying very hard to avoid. (It's only
+  // okay here because it's test code that is only called every five minutes, so we can be a bit lazy.)
+  var _originalSchedule: Option[String] = None
+  var _adjustedSchedule: Option[AdjustedSchedule] = None
 
   def getSchedule(): EssentialAction = Action { implicit request =>
-    val s: String = _theSchedule match {
+    val originalScheduleStr: String = _originalSchedule match {
       case Some(schedule) => schedule
       case None => {
         // Our test data is the 2014 schedule in JSONP format. Translate that into JSON, which is what we now
@@ -37,11 +63,23 @@ class FakeZambiaController (
         val schedule = Schedule.parseKonOpas(jsonp)
         // TODO: massage the timing of the schedule so that it is happening today
         // TODO: massage the rooms in the schedule to match our actual rooms, and reduce to fewer of them
-        _theSchedule = Some(Json.toJson(schedule).toString())
-        _theSchedule.get
+        _originalSchedule = Some(Json.toJson(schedule).toString())
+        _originalSchedule.get
       }
     }
 
-    Ok(s)
+    val s = _adjustedSchedule match {
+      case Some(schedule) if schedule.today == LocalDate.now() => schedule
+      case _ => {
+        // Either we don't have any Schedule yet, or we've moved to a new day and need to readjust:
+        logger.info(s"Readjusting the test schedule")
+        val originalSchedule = Json.parse(originalScheduleStr).as[Schedule]
+        val newSchedule = AdjustedSchedule(originalSchedule)
+        _adjustedSchedule = Some(newSchedule)
+        newSchedule
+      }
+    }
+
+    Ok(s.stringified)
   }
 }


### PR DESCRIPTION
For the moment, we're still using the 2014 Zambia data, but we're massaging it so that it always produces a Schedule that consists of yesterday/today/tomorrow/day-after -- all of the dates are pushed forward to be "now". This will permit us to test what things look like when the site is live day-of.

(Obviously this will eventually have to go behind a switch of some sort, and we'll probably switch over to the real A'21 data sometime soon, but this is a step in the right direction.)

The frontend isn't using this data yet, since it's not fetching the Schedule from the backend -- I'll let the frontend team flip the switch in `schedule.service.ts` when they're comfortable with it.  The only thing I notice broken when I do that is that the Day filter at the top of the Schedule page no longer works, because the dates in `filters.component.html` are hardcoded to 2014.  I don't know whether it's feasible to make those dynamically show the same yesterday/today/tomorrow/day-after dates that the backend is returning.