### PR TITLE
Add a config flag so that you can set yourself as an Admin in your de…

### DIFF
--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -22,9 +22,6 @@ class LoginController (
 
   lazy val earlyAccessOnly: Boolean = config.get[Boolean]("arisia.early.access.only")
 
-  lazy val allowedLogins: Seq[LoginId] =
-    config.get[Seq[String]]("arisia.allow.logins").map(LoginId(_))
-
   def me(): EssentialAction = Action { implicit request =>
     request.session.get(userKey) match {
       case Some(jsonStr) => Ok(jsonStr)
@@ -42,9 +39,11 @@ class LoginController (
             val allowed =
               if (earlyAccessOnly) {
                 // We're in early-access mode, so the general public is *not* allowed in
-                // In a dev environment, add your login to `arisia.allow.logins` in order to permit your own login:
-                permissions.superAdmin || permissions.admin || permissions.earlyAccess || allowedLogins.contains(user.id)
+                // For local dev environments, add your CM username to either arisia.allow.logins or
+                // arisia.dev.admins in secrets.conf, to give yourself access:
+                permissions.hasEarlyAccess
               } else {
+                // The doors are open -- everyone can log in:
                 true
               }
 

--- a/arisia-remote/app/arisia/models/Permissions.scala
+++ b/arisia-remote/app/arisia/models/Permissions.scala
@@ -10,7 +10,9 @@ package arisia.models
  * @param admin Permits access to the Admin pages
  * @param earlyAccess Allows this user to log into the site before we open it to all current members
  */
-case class Permissions(superAdmin: Boolean, admin: Boolean, earlyAccess: Boolean)
+case class Permissions(superAdmin: Boolean, admin: Boolean, earlyAccess: Boolean) {
+  lazy val hasEarlyAccess = superAdmin || admin || earlyAccess
+}
 
 object Permissions {
   val empty = Permissions(false, false, false)

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -16,6 +16,10 @@ play.assets.urlPrefix = "/admin/assets"
 arisia {
   # Set this to false to open the doors to the public:
   early.access.only = true
+
+  # These are both for use in local development in secrets.conf:
+  allow.logins = []
+  dev.admins = []
 }
 
 # All secrets MUST go into the .gitignore'd secrets.conf file. See secrets.conf.template for details.

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -14,3 +14,5 @@ db.default.url = "<JDBC URL for Postgres DB>"
 
 # Put your own login here in dev environments, to allow access for yourself:
 arisia.allow.logins = []
+# Similarly, put your login here to give yourself admin access (which includes frontend access):
+arisia.dev.admins = []


### PR DESCRIPTION
…v environment

If you would like to be able to use the Admin UI in your development environment, add your CM username to `arisia.dev.admins` in `secrets.conf`. For example, in my `secrets.conf`, I would have:
```
arisia.dev.admins = ["jducoeur"]
```
Along with this, did a bit of refactoring to keep this sort of config mungery in better-contained places, so the controller doesn't need to worry about it.