### PR TITLE
Add star selections

### DIFF
--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -1,11 +1,11 @@
 package arisia
 
 import akka.actor.ActorSystem
-import arisia.admin.{AdminService, AdminServiceImpl}
+import arisia.admin.{AdminServiceImpl, AdminService}
 import arisia.auth.{LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
 import com.softwaremill.macwire.wire
-import arisia.schedule.{ScheduleServiceImpl, ScheduleService}
+import arisia.schedule.{ScheduleServiceImpl, ScheduleService, StarService, StarServiceImpl}
 import arisia.timer.{TimerServiceImpl, Ticker, TimerService, TickerImpl}
 import play.api.Configuration
 import play.api.libs.ws.WSClient
@@ -22,6 +22,7 @@ trait GeneralModule {
   def actorSystem: ActorSystem
 
   lazy val scheduleService: ScheduleService = wire[ScheduleServiceImpl]
+  lazy val starService: StarService = wire[StarServiceImpl]
   lazy val loginService: LoginService = wire[LoginServiceImpl]
   lazy val dbService: DBService = wire[DBServiceImpl]
   lazy val ticker: Ticker = wire[TickerImpl]

--- a/arisia-remote/app/arisia/controllers/LoginControllerFuncs.scala
+++ b/arisia-remote/app/arisia/controllers/LoginControllerFuncs.scala
@@ -1,0 +1,22 @@
+package arisia.controllers
+
+import arisia.models.{LoginId, LoginUser}
+import play.api.mvc.{Request, AnyContent, BaseController, EssentialAction, Result}
+
+import scala.concurrent.Future
+
+/**
+ * Mixin trait for controllers, to make it easy to define functions that are only available to logged-in users.
+ */
+trait LoginControllerFuncs extends BaseController {
+  case class LoggedInRequest(who: LoginUser, request: Request[AnyContent])
+
+  def withLoggedInAsync(f: LoggedInRequest => Future[Result]): EssentialAction = Action.async { implicit request =>
+    LoginController.loggedInUser() match {
+      case Some(user) => {
+        f(LoggedInRequest(user, request))
+      }
+      case _ => Future.successful(Forbidden("You need to be logged in to do this"))
+    }
+  }
+}

--- a/arisia-remote/app/arisia/controllers/ScheduleController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleController.scala
@@ -1,6 +1,7 @@
 package arisia.controllers
 
-import arisia.schedule.ScheduleService
+import arisia.models.ProgramItemId
+import arisia.schedule.{ScheduleService, StarService}
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
 
@@ -8,15 +9,34 @@ import scala.concurrent.ExecutionContext
 
 class ScheduleController(
   val controllerComponents: ControllerComponents,
-  scheduleService: ScheduleService
+  scheduleService: ScheduleService,
+  starService: StarService
 )(
   implicit ec: ExecutionContext
 )
-  extends BaseController
+  extends BaseController with LoginControllerFuncs
 {
   def getSchedule(): EssentialAction = Action { implicit request =>
     val schedule = scheduleService.currentSchedule()
     val json = Json.toJson(schedule)
     Ok(json).as(JSON)
+  }
+
+  def addStar(whichStr: String): EssentialAction = withLoggedInAsync { info =>
+    starService.addStar(info.who.id, ProgramItemId(whichStr)).map { _ =>
+      Ok("")
+    }
+  }
+
+  def removeStar(whichStr: String): EssentialAction = withLoggedInAsync { info =>
+    starService.removeStar(info.who.id, ProgramItemId(whichStr)).map { _ =>
+      Ok("")
+    }
+  }
+
+  def getStars(): EssentialAction = withLoggedInAsync { info =>
+    starService.getStars(info.who.id).map { stars =>
+      Ok(Json.toJson(stars).toString())
+    }
   }
 }

--- a/arisia-remote/app/arisia/schedule/StarService.scala
+++ b/arisia-remote/app/arisia/schedule/StarService.scala
@@ -1,0 +1,58 @@
+package arisia.schedule
+
+import arisia.db.DBService
+import arisia.models.{ProgramItemId, LoginId}
+import arisia.util.Done
+import play.api.Logging
+import doobie._
+import doobie.implicits._
+
+import scala.concurrent.Future
+
+/**
+ * A simple service for tracking which program items a user has starred.
+ */
+trait StarService {
+  def addStar(who: LoginId, which: ProgramItemId): Future[Int]
+  def removeStar(who: LoginId, which: ProgramItemId): Future[Int]
+  def getStars(who: LoginId): Future[List[ProgramItemId]]
+}
+
+class StarServiceImpl(
+  dbService: DBService
+) extends StarService with Logging {
+  def addStar(who: LoginId, which: ProgramItemId): Future[Int] = {
+    val query =
+      sql"""INSERT INTO starred_items
+           (login_id, item_id)
+           VALUES (${who.v}, ${which.v})"""
+    dbService.run(
+      query.
+        update.
+        run
+    )
+  }
+
+  def removeStar(who: LoginId, which: ProgramItemId): Future[Int] = {
+    val query =
+      sql"""DELETE FROM starred_items
+           WHERE login_id = ${who.v} AND item_id = ${which.v}"""
+    dbService.run(
+      query.
+        update.
+        run
+    )
+  }
+
+  def getStars(who: LoginId): Future[List[ProgramItemId]] = {
+    val query =
+      sql"""SELECT item_id
+           FROM starred_items
+           WHERE login_id = ${who.v}"""
+    dbService.run(
+      query.
+        query[ProgramItemId]
+        .to[List]
+    )
+  }
+}

--- a/arisia-remote/app/arisia/util/package.scala
+++ b/arisia-remote/app/arisia/util/package.scala
@@ -1,4 +1,6 @@
 package arisia
 
 package object util {
+  case object Done
+  type Done = Done.type
 }

--- a/arisia-remote/conf/evolutions/default/4.sql
+++ b/arisia-remote/conf/evolutions/default/4.sql
@@ -1,0 +1,13 @@
+-- !Ups
+
+-- This is a simple join table (conceptually) of users and their starred program items.
+
+CREATE TABLE starred_items (
+  login_id text NOT NULL,
+  item_id text NOT NULL,
+  PRIMARY KEY (login_id)
+);
+
+-- !Downs
+
+DROP TABLE starred_items;

--- a/arisia-remote/conf/evolutions/default/4.sql
+++ b/arisia-remote/conf/evolutions/default/4.sql
@@ -4,9 +4,12 @@
 
 CREATE TABLE starred_items (
   login_id text NOT NULL,
-  item_id text NOT NULL,
-  PRIMARY KEY (login_id)
+  item_id text NOT NULL
 );
+
+-- Note that we specifically want a non-unique index, so it's not a primary key:
+
+CREATE INDEX star_index ON starred_items (login_id);
 
 -- !Downs
 

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -29,6 +29,12 @@ POST    /api/logout                  arisia.controllers.LoginController.logout()
 
 # Fetches the current schedule
 GET     /api/schedule                arisia.controllers.ScheduleController.getSchedule()
+# Fetch the stars for the current user; returns a JSON list of program IDs
+GET     /api/schedule/stars          arisia.controllers.ScheduleController.getStars()
+# Add a star from the specified program item ID
+PUT     /api/schedule/stars/:which   arisia.controllers.ScheduleController.addStar(which)
+# Remove the star for the specified program item ID
+DELETE  /api/schedule/stars/:which   arisia.controllers.ScheduleController.removeStar(which)
 
 # Admin UI, separate from the attendee-facing site
 GET     /admin                       arisia.controllers.AdminController.home()

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -52,5 +52,10 @@ GET     /admin/assets/*file          controllers.Assets.versioned(path="/public"
 # Zambia emulator, providing test data
 GET     /test/fakeschedule           arisia.controllers.FakeZambiaController.getSchedule()
 
+# During development, get the Swagger UI at:
+#   http://localhost:9000/docs/swagger-ui/index.html?url=/admin/assets/swagger.json
+### NoDocs ###
+GET   /docs/swagger-ui/*file        controllers.Assets.at(path:String="/public/lib/swagger-ui", file:String)
+
 # Fetch frontend assets
 GET     /*file                       arisia.controllers.FrontendController.assetOrDefault(file)

--- a/arisia-remote/conf/swagger.yml
+++ b/arisia-remote/conf/swagger.yml
@@ -1,0 +1,9 @@
+---
+  swagger: "2.0"
+  info:
+    title: "Arisia 2021 API"
+    description: "Backend for the A'21 website"
+  consumes:
+    - application/json
+  produces:
+    - application/json

--- a/build.sbt
+++ b/build.sbt
@@ -110,10 +110,12 @@ lazy val backend = (project in file("arisia-remote"))
       macwireUtil,
       scalactic,
       scalaTest,
-      scalatestPlusPlay
-    )
+      scalatestPlusPlay,
+      swaggerUI
+    ),
+    swaggerDomainNameSpaces := Seq("arisia.models")
   )
-  .enablePlugins(PlayScala)
+  .enablePlugins(PlayScala, SwaggerPlugin)
 
 lazy val frontend = (project in file("frontend"))
   .settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,8 @@ object Dependencies {
 
   val scalatestPlusPlayVersion = "5.0.0"
 
+  val swaggerUIVersion = "3.35.0"
+
   ///////////////////////
 
   val betterFiles = "com.github.pathikrit" %% "better-files" % betterFilesVersion
@@ -39,4 +41,6 @@ object Dependencies {
   val scalactic = "org.scalactic" %% "scalactic" % scalaTestVersion
   val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
   val scalatestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % scalatestPlusPlayVersion % Test
+
+  val swaggerUI = "org.webjars" % "swagger-ui" % swaggerUIVersion
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+
+addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.10.2-PLAY2.8")


### PR DESCRIPTION
Fixes #150 

This introduces endpoints to add, remove, and fetch "stars" on specific schedule items -- basically, allowing the user to highlight items that they want to keep track of in the schedule.  This matches the stars in the current design.

In order to allow me to test this, this PR also introduces automatic Swagger API-doc generation, and a UI for manually testing the API; this can be found at http://localhost:9000/docs/swagger-ui/index.html?url=/admin/assets/swagger.json
