### PR TITLE
Beginnings of Zoom Automation

### DIFF
--- a/arisia-remote/app/arisia/PlayComponents.scala
+++ b/arisia-remote/app/arisia/PlayComponents.scala
@@ -5,6 +5,7 @@ import play.api._
 import com.softwaremill.macwire._
 import _root_.controllers.AssetsComponents
 import arisia.controllers.ControllerModule
+import arisia.zoom.ZoomModule
 import play.api.db.{DBComponents, HikariCPComponents}
 import play.api.db.evolutions.EvolutionsComponents
 import play.api.i18n.I18nComponents
@@ -35,6 +36,7 @@ class PlayComponents(context: Context)
   with AhcWSComponents
   with ControllerModule
   with GeneralModule
+  with ZoomModule
 {
   // When starting the application, run database evolutions and apply changes if needed:
   applicationEvolutions

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -3,19 +3,22 @@ package arisia.controllers
 import arisia.admin.AdminService
 import arisia.auth.LoginService
 import arisia.models.{LoginName, LoginUser, Permissions, LoginId}
+import arisia.zoom.ZoomService
 import play.api.Logging
 import play.api.mvc._
 import play.api.data._
 import play.api.data.Forms._
 import play.api.http.Writeable
 import play.api.i18n.I18nSupport
+import play.api.libs.json.Json
 
 import scala.concurrent.{Future, ExecutionContext}
 
 class AdminController (
   val controllerComponents: ControllerComponents,
   adminService: AdminService,
-  loginService: LoginService
+  loginService: LoginService,
+  zoomService: ZoomService
 )(
   implicit ec: ExecutionContext
 ) extends BaseController
@@ -75,6 +78,21 @@ class AdminController (
       "username" -> nonEmptyText
     )(LoginId.apply)(LoginId.unapply)
   )
+
+  /* ********************
+   *
+   * Other ad-hoc functions
+   *
+   */
+
+  /**
+   * For now, this is internal-only, for testing, and can only be accessed from Swagger.
+   */
+  def startMeeting(): EssentialAction = adminsOnlyAsync { info =>
+    zoomService.startMeeting("Ad hoc meeting").map { meeting =>
+      Ok(Json.toJson(meeting).toString())
+    }
+  }
 
   /* ********************
    *

--- a/arisia-remote/app/arisia/controllers/ControllerModule.scala
+++ b/arisia-remote/app/arisia/controllers/ControllerModule.scala
@@ -3,6 +3,7 @@ package arisia.controllers
 import arisia.GeneralModule
 import arisia.auth.LoginService
 import arisia.schedule.ScheduleService
+import arisia.zoom.ZoomModule
 import com.softwaremill.macwire._
 import controllers.Assets
 import play.api.Configuration
@@ -11,7 +12,7 @@ import play.api.mvc.ControllerComponents
 
 import scala.concurrent.ExecutionContext
 
-trait ControllerModule extends GeneralModule {
+trait ControllerModule extends GeneralModule with ZoomModule {
   implicit def executionContext: ExecutionContext
   def controllerComponents: ControllerComponents
   def assets: Assets
@@ -22,6 +23,7 @@ trait ControllerModule extends GeneralModule {
   lazy val scheduleController: ScheduleController = wire[ScheduleController]
   lazy val frontendController: FrontendController = wire[FrontendController]
   lazy val adminController: AdminController = wire[AdminController]
+  lazy val zoomController: ZoomController = wire[ZoomController]
 
   lazy val fakeZambiaController: FakeZambiaController = wire[FakeZambiaController]
 }

--- a/arisia-remote/app/arisia/controllers/ZoomController.scala
+++ b/arisia-remote/app/arisia/controllers/ZoomController.scala
@@ -1,0 +1,25 @@
+package arisia.controllers
+
+import arisia.zoom.ZoomService
+import play.api.mvc.{BaseController, EssentialAction, ControllerComponents}
+
+import scala.concurrent.ExecutionContext
+
+/**
+ * This controller manages all external entry points that are Zoom-specific.
+ */
+class ZoomController(
+  val controllerComponents: ControllerComponents,
+  zoomService: ZoomService
+)(
+  implicit ec: ExecutionContext
+) extends BaseController {
+
+  // TODO: get rid of this. There isn't much harm to it, but we won't need it once integration is really working,
+  // and there is no point leaving extra entry points around for potential mischief.
+  def test(): EssentialAction = Action.async { implicit request =>
+    zoomService.getUsers().map { _ =>
+      Ok("Got it!")
+    }
+  }
+}

--- a/arisia-remote/app/arisia/zoom/JwtService.scala
+++ b/arisia-remote/app/arisia/zoom/JwtService.scala
@@ -1,0 +1,67 @@
+package arisia.zoom
+
+import play.api.Configuration
+import play.api.libs.json._
+import java.time.{Clock, Duration}
+
+import pdi.jwt.JwtSession
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * This little tool deals with creating the JWTs for Zoom.
+ *
+ * This also tells you whether Zoom integration is enabled locally. (Since it wraps the API Key and Secret, it knows
+ * whether you've provided the necessary bits.)
+ */
+trait JwtService {
+  /**
+   * Is Zoom integration enabled on this site or not?
+   */
+  def zoomEnabled: Boolean
+
+  /**
+   * Fetches a short-lived, one-shot, JWT for talking to Zoom.
+   *
+   * IMPORTANT: for security reasons, this JWT doesn't last for long, so only use it for a single request. They
+   * aren't so expensive to generate that we need to reuse them.
+   */
+  def getJwtToken(): String
+}
+
+class JwtServiceImpl(
+  mainConfig: Configuration
+) extends JwtService with DefaultWrites {
+
+  implicit val clock = Clock.systemUTC()
+
+  lazy val apiKey = mainConfig.get[String]("arisia.zoom.api.key")
+  lazy val apiSecret = mainConfig.get[String]("arisia.zoom.api.secret")
+  lazy val apiTimeout = mainConfig.get[Long]("arisia.zoom.api.timeout")
+
+  /**
+   * The JWT library uses the standard Play settings, but we really don't want that here: we want short-lived
+   * JWTs, in contrast to the long-lived ones for user session cookies.
+   */
+  lazy val jwtConfig =
+    Configuration(
+      "play.http.secret.key" -> apiSecret,
+      "play.http.session.privateKey" -> apiSecret,
+      "play.http.session.maxAge" -> apiTimeout
+    )
+
+  implicit val conf = jwtConfig
+
+  lazy val zoomEnabled: Boolean = apiKey.length > 0 && apiSecret.length > 0
+
+  def getJwtToken(): String = {
+    // Note that the expiration is milliseconds in config, but Zoom requires that we specify it in seconds:
+    val expSeconds = clock.instant().plus(Duration.ofMillis(apiTimeout)).getEpochSecond
+    // Conveniently, Zoom and JwtSession both default to HS256, so we can just use the default constructor:
+    // The syntax here looks dumb because multiarg infix is being phased out in Scala, so the way this is
+    // intended to be used now generates warnings:
+    val session =
+      JwtSession().++(("iss", apiKey), ("exp", expSeconds))
+    "Bearer " + session.serialize
+  }
+}

--- a/arisia-remote/app/arisia/zoom/ZoomModule.scala
+++ b/arisia-remote/app/arisia/zoom/ZoomModule.scala
@@ -1,0 +1,21 @@
+package arisia.zoom
+
+import play.api.Configuration
+import com.softwaremill.macwire.wire
+
+import scala.concurrent.ExecutionContext
+import play.api.libs.ws.WSClient
+
+trait ZoomModule {
+  implicit def executionContext: ExecutionContext
+  def configuration: Configuration
+  def wsClient: WSClient
+
+  lazy val jwtService: JwtService = wire[JwtServiceImpl]
+  lazy val zoomService: ZoomService = {
+    if (jwtService.zoomEnabled)
+      wire[ZoomServiceImpl]
+    else
+      wire[DisabledZoomService]
+  }
+}

--- a/arisia-remote/app/arisia/zoom/ZoomService.scala
+++ b/arisia-remote/app/arisia/zoom/ZoomService.scala
@@ -1,0 +1,47 @@
+package arisia.zoom
+
+import arisia.zoom.models.ZoomUser
+import play.api.{Configuration, Logging}
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{Future, ExecutionContext}
+
+/**
+ * Logical layer over the Zoom API.
+ *
+ * This doesn't try to impose any semantics -- it is just a relatively thin pass-through.
+ */
+trait ZoomService {
+  def getUsers(): Future[List[ZoomUser]]
+}
+
+class ZoomServiceImpl(
+  config: Configuration,
+  ws: WSClient,
+  jwtService: JwtService
+)(
+  implicit ec: ExecutionContext
+) extends ZoomService with Logging {
+
+  lazy val baseUrl: String = config.get[String]("arisia.zoom.api.baseUrl")
+
+  def getUsers(): Future[List[ZoomUser]] = {
+    val jwt = jwtService.getJwtToken()
+    // TODO: remove
+    logger.info(s"The JWT is $jwt")
+    ws.url(s"$baseUrl/users")
+      .addHttpHeaders(
+        ("Authorization", jwt)
+      )
+      .get()
+      .map { response =>
+        // TODO: remove the log, and make the response real.
+        logger.info(s"The response from Zoom is $response, body ${response.body}")
+        List.empty
+      }
+  }
+}
+
+class DisabledZoomService() extends ZoomService {
+  def getUsers(): Future[List[ZoomUser]] = ???
+}

--- a/arisia-remote/app/arisia/zoom/models/ZoomMeeting.scala
+++ b/arisia-remote/app/arisia/zoom/models/ZoomMeeting.scala
@@ -1,0 +1,28 @@
+package arisia.zoom.models
+
+import play.api.libs.json.{Format, Json}
+
+/**
+ * The information we get back from Zoom when we create a Meeting.
+ *
+ * This is not the full data structure: we are only bothering to deserialize fields that we might possibly
+ * care about.
+ */
+case class ZoomMeeting(
+  id: Long,
+  topic: String,
+  created_at: String,
+  start_url: String,
+  join_url: String,
+  password: String
+)
+object ZoomMeeting {
+  implicit val fmt: Format[ZoomMeeting] = Json.format
+}
+
+object ZoomMeetingType {
+  final val Instant = 1
+  final val Scheduled = 2
+  final val RecurringUnfixed = 3
+  final val RecurringFixed = 8
+}

--- a/arisia-remote/app/arisia/zoom/models/ZoomUser.scala
+++ b/arisia-remote/app/arisia/zoom/models/ZoomUser.scala
@@ -1,0 +1,3 @@
+package arisia.zoom.models
+
+case class ZoomUser(id: Option[String], firstName: Option[String], lastName: Option[String], email: String)

--- a/arisia-remote/app/arisia/zoom/models/package.scala
+++ b/arisia-remote/app/arisia/zoom/models/package.scala
@@ -1,0 +1,5 @@
+package arisia.zoom
+
+package object models {
+  type ZoomMeetingType = Int
+}

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -20,6 +20,15 @@ arisia {
   # These are both for use in local development in secrets.conf:
   allow.logins = []
   dev.admins = []
+
+  zoom.api {
+    # These get put into your secrets.conf in order to turn on Zoom integration:
+    key = ""
+    secret = ""
+    # JWTs are valid for one minute:
+    timeout = 60000
+    baseUrl = "https://api.zoom.us/v2"
+  }
 }
 
 # All secrets MUST go into the .gitignore'd secrets.conf file. See secrets.conf.template for details.

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -28,6 +28,8 @@ arisia {
     # JWTs are valid for one minute:
     timeout = 60000
     baseUrl = "https://api.zoom.us/v2"
+    # The Zoom User ID being used to create meetings, in secrets.conf:
+    userId = ""
   }
 }
 

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -45,6 +45,8 @@ DELETE  /admin/manageAdmins/:name    arisia.controllers.AdminController.removeAd
 GET     /admin/manageEarlyAccess          arisia.controllers.AdminController.manageEarlyAccess()
 POST    /admin/manageEarlyAccess          arisia.controllers.AdminController.addEarlyAccess()
 DELETE  /admin/manageEarlyAccess/:name    arisia.controllers.AdminController.removeEarlyAccess(name)
+# This is mainly internal, for testing; we might add a UI if we find a use for it, but don't do that casually:
+POST    /admin/startAdHocMeeting     arisia.controllers.AdminController.startMeeting()
 # Note the non-standard path, which is configured in application.conf, so that frontend
 # can own /assets
 GET     /admin/assets/*file          controllers.Assets.versioned(path="/public", file: Asset)

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -51,6 +51,8 @@ GET     /admin/assets/*file          controllers.Assets.versioned(path="/public"
 
 # Zambia emulator, providing test data
 GET     /test/fakeschedule           arisia.controllers.FakeZambiaController.getSchedule()
+# TODO: remove
+GET     /test/zoomcall               arisia.controllers.ZoomController.test()
 
 # During development, get the Swagger UI at:
 #   http://localhost:9000/docs/swagger-ui/index.html?url=/admin/assets/swagger.json

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -22,3 +22,7 @@ arisia.dev.admins = []
 # If these are empty, Zoom integration will be turned off.
 arisia.zoom.api.key = ""
 arisia.zoom.api.secret = ""
+# This must be the ID of a user on this Zoom account. It isn't easy to find this ID -- I find it by going into
+# User Management in the Zoom account UI, clicking on the target user, and pulling the ID from the URL. There is
+# probably a way to get it from the account UI, but I haven't found it yet.
+arisia.zoom.api.userId = ""

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -16,3 +16,9 @@ db.default.url = "<JDBC URL for Postgres DB>"
 arisia.allow.logins = []
 # Similarly, put your login here to give yourself admin access (which includes frontend access):
 arisia.dev.admins = []
+
+# These need to be filled in with a registered Zoom app's API Key and Secret. See:
+#   https://marketplace.zoom.us/docs/guides/build/jwt-app
+# If these are empty, Zoom integration will be turned off.
+arisia.zoom.api.key = ""
+arisia.zoom.api.secret = ""

--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,7 @@ lazy val backend = (project in file("arisia-remote"))
       catsCore,
       doobieCore,
       doobiePostgres,
+      jwtPlay,
       macwireMacros,
       macwireUtil,
       scalactic,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,8 @@ object Dependencies {
 
   val doobieVersion = "0.9.0"
 
+  val jwtPlayVersion = "4.2.0"
+
   val macwireVersion = "2.3.7"
 
   val postgresDriverVersion = "42.2.18"
@@ -34,6 +36,8 @@ object Dependencies {
 
   val doobieCore = "org.tpolecat" %% "doobie-core" % doobieVersion
   val doobiePostgres = "org.tpolecat" %% "doobie-postgres" % doobieVersion
+
+  val jwtPlay = "com.pauldijou" %% "jwt-play" % jwtPlayVersion
 
   val macwireMacros = "com.softwaremill.macwire" %% "macros" % macwireVersion % "provided"
   val macwireUtil = "com.softwaremill.macwire" %% "util" % macwireVersion


### PR DESCRIPTION
This is *not* yet full meeting automation -- far from it -- but we've now crossed the critical Rubicon: the backend is capable of starting Zoom meetings.

This adds an Admin endpoint with (intentionally) no UI, to create ad-hoc meetings, for testing all of this. This can basically only be called by Admins from Swagger, and is hard to use, so I don't expect anybody to abuse it.

Being able to do this is *enormously* informative, and may require a tweak or two to our plans, but it's mostly working as expected.