### PR TITLE
Make the schedule properly cacheable on the frontend

### DIFF
--- a/arisia-remote/app/arisia/models/Schedule.scala
+++ b/arisia-remote/app/arisia/models/Schedule.scala
@@ -1,11 +1,19 @@
 package arisia.models
 
 import play.api.libs.json._
+import com.roundeights.hasher.Implicits._
+import scala.language.postfixOps
 
 /**
  * The representation of the entire schedule.
  */
-case class Schedule(program: List[ProgramItem], people: List[ProgramPerson])
+case class Schedule(program: List[ProgramItem], people: List[ProgramPerson]) {
+  lazy val json: String = Json.toJson(this).toString()
+  // Note that we do *not* care about a cryptographically-sound hash here -- we just need something large and
+  // well-enough-distributed to make hash collisions unlikely. So MD5 should suffice -- we don't need to waste
+  // extra cycles on SHA256 or BCrypt:
+  lazy val hash: String = json.md5.hex
+}
 
 object Schedule {
   implicit val scheduleFormat: Format[Schedule] = Json.format

--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,7 @@ lazy val backend = (project in file("arisia-remote"))
       catsCore,
       doobieCore,
       doobiePostgres,
+      hasher,
       jwtPlay,
       macwireMacros,
       macwireUtil,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,8 @@ object Dependencies {
 
   val doobieVersion = "0.9.0"
 
+  val hasherVersion = "1.2.2"
+
   val jwtPlayVersion = "4.2.0"
 
   val macwireVersion = "2.3.7"
@@ -36,6 +38,8 @@ object Dependencies {
 
   val doobieCore = "org.tpolecat" %% "doobie-core" % doobieVersion
   val doobiePostgres = "org.tpolecat" %% "doobie-postgres" % doobieVersion
+
+  val hasher = "com.outr" %% "hasher" % hasherVersion
 
   val jwtPlay = "com.pauldijou" %% "jwt-play" % jwtPlayVersion
 


### PR DESCRIPTION
This adds an `ETag` header from the getSchedule() endpoint -- an MD5 hash of the current schedule. The frontend should return that in an `If-None-Match` header, and the backend will simply return 304 (Not Modified) in the usual case that nothing has changed.

Note that the HTTP standard expects the hash to be in double quotes in both the `ETag` and `If-None-Match` headers: the backend is expecting that.

This also tweaks things to cache the JSON-serialized form of the Schedule, so we don't have to recompute that on every fetch.