### PR TITLE
Add a `timestamp` field for Program Items

### DIFF
--- a/arisia-remote/app/arisia/models/ProgramItem.scala
+++ b/arisia-remote/app/arisia/models/ProgramItem.scala
@@ -1,7 +1,7 @@
 package arisia.models
 
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, LocalTime}
+import java.time.{LocalDate, LocalTime, Instant}
 
 import arisia.util._
 import play.api.libs.json._
@@ -53,6 +53,14 @@ object ProgramItemTime {
   }
 }
 
+case class ProgramItemTimestamp(t: Instant)
+object ProgramItemTimestamp {
+  implicit val reads: Reads[ProgramItemTimestamp] =
+    JsUtils.stringReads(str => new ProgramItemTimestamp(Instant.parse(str)))
+
+  implicit val writes: Writes[ProgramItemTimestamp] = (o: ProgramItemTimestamp) => JsString(o.t.toString)
+}
+
 /**
  * Represents a Program Item, in a way that exactly matches KonOpas.
  *
@@ -71,7 +79,8 @@ case class ProgramItem(
   mins: Option[String],
   loc: List[ProgramItemLoc],
   people: List[ProgramItemPerson],
-  desc: Option[ProgramItemDesc]
+  desc: Option[ProgramItemDesc],
+  timestamp: Option[ProgramItemTimestamp]
 )
 object ProgramItem {
   implicit val fmt: Format[ProgramItem] = (
@@ -83,6 +92,7 @@ object ProgramItem {
       (JsPath \ "mins").formatNullable[String] and
       (JsPath \ "loc").formatWithDefault[List[ProgramItemLoc]](List.empty) and
       (JsPath \ "people").formatWithDefault[List[ProgramItemPerson]](List.empty) and
-      (JsPath \ "desc").formatNullable[ProgramItemDesc]
+      (JsPath \ "desc").formatNullable[ProgramItemDesc] and
+      (JsPath \ "timestamp").formatNullable[ProgramItemTimestamp]
     )(ProgramItem.apply, unlift(ProgramItem.unapply))
 }

--- a/arisia-remote/app/arisia/models/Schedule.scala
+++ b/arisia-remote/app/arisia/models/Schedule.scala
@@ -22,8 +22,9 @@ object Schedule {
 
   /**
    * Given a dump from Zambia, parse that into our internal structure.
+   *
+   * TODO: this is mostly obsolete, since we are now getting JSON from Zambia instead of KonOpas JSONP.
    */
-  // TODO: wrap this in some sort of validation type, so we can cope cleanly with errors:
   def parseKonOpas(konopasJsonp: String): Schedule = {
     // We are assuming the format of the JSONP pretty precisely -- it's generated, so we should be able to count
     // on it. This is a known fragility, but we aren't pretending that this is general-purpose at this stage of the


### PR DESCRIPTION
In order to reduce the processing effort required on the front end, we are computing ISO-8601 timestamps on the backend, and adding them as a new synthesized field in the Zambia data. The format is, eg, `2020-12-28T01:30:00Z` -- the ISO "Instant" format.

Fixes #157 