### PR TITLE
Fetch the real Schedule from Zambia

### DIFF
--- a/arisia-remote/app/arisia/schedule/ScheduleService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleService.scala
@@ -3,13 +3,14 @@ package arisia.schedule
 import java.time.{LocalDateTime, ZoneId}
 import java.util.concurrent.atomic.AtomicReference
 
+import scala.concurrent.duration._
 import arisia.db.DBService
 import arisia.models.{Schedule, ProgramItemTimestamp}
 import doobie._
 import doobie.implicits._
-import play.api.Logging
+import play.api.{Configuration, Logging}
 import play.api.libs.json.Json
-import play.api.libs.ws.WSClient
+import play.api.libs.ws.{WSClient, WSCookie}
 
 import scala.concurrent.{Future, ExecutionContext}
 
@@ -27,10 +28,16 @@ trait ScheduleService {
 
 class ScheduleServiceImpl(
   dbService: DBService,
-  ws: WSClient
+  ws: WSClient,
+  config: Configuration
 )(
   implicit ec: ExecutionContext
 ) extends ScheduleService with Logging {
+
+  lazy val zambiaUrl = config.get[String]("arisia.zambia.url")
+  lazy val zambiaLoginUrl = config.get[String]("arisia.zambia.loginUrl")
+  lazy val zambiaBadgeId = config.get[String]("arisia.zambia.badgeId")
+  lazy val zambiaPassword = config.get[String]("arisia.zambia.password")
 
   /**
    * The timezone that the Zambia data is assuming.
@@ -84,41 +91,57 @@ class ScheduleServiceImpl(
     _theSchedule.set(ScheduleCache(json))
   }
 
+  def logIntoZambia(): Future[Seq[WSCookie]] = {
+    ws.url(zambiaLoginUrl)
+      .withRequestTimeout(10.seconds)
+      .post(Map(
+        "badgeid" -> zambiaBadgeId,
+        "passwd" -> zambiaPassword
+      )).map { response =>
+        response.cookies.toSeq
+      }
+  }
+
   /**
    * Go out to Zambia, and fetch the current version of the schedule.
    *
    * This is called by the TimerService periodically.
    */
   def refresh(): Unit = {
-    // TODO: make the URL configurable so that we can actually point it to Zambia. But until we have
-    // that, it can just be hardcoded.
-    ws.url("http://localhost:9000/test/fakeschedule")
-      .get()
-      .map { response =>
-        val json = response.body
-        if (json == _theSchedule.get.jsonStr) {
-          logger.info(s"Refresh -- schedule hasn't changed")
-        } else {
-          logger.info(s"Refreshed the schedule from Zambia -- size ${json.length}")
-          // TODO: don't actually set the cache until we validate that the jsonp validates:
-          val cacheable = ScheduleCache(json)
-          try {
-            // For the moment, this can throw Exceptions.
-            // TODO: make this pathway non-Exception-centric.
-            val parsed = cacheable.parsed
-            // Save it in the DB:
-            dbService.run(updateScheduleStatement(json)).map { _ =>
-              logger.info(s"Saved new Schedule in the database")
-              // Once that's done, cache it:
-              _theSchedule.set(ScheduleCache(json))
-            }
-          } catch {
-            case ex: Exception => {
-              logger.error(s"Unable to parse Schedule that we received from Zambia!")
+    // For the moment, we are logging in each time
+    // TODO: cache the login cookies, and try using those instead of re-logging in each time. The current
+    // approach works, but is a bit of extra labor for both Remote and Zambia.
+    logIntoZambia().flatMap { cookies =>
+      ws.url(zambiaUrl)
+        .addCookies(cookies:_*)
+        .get()
+        .map { response =>
+          val json = response.body
+          if (json == _theSchedule.get.jsonStr) {
+            logger.info(s"Refresh -- schedule hasn't changed")
+          } else {
+            logger.info(s"Refreshed the schedule from Zambia -- size ${json.length}")
+            // TODO: don't actually set the cache until we validate that the jsonp validates:
+            val cacheable = ScheduleCache(json)
+            try {
+              // For the moment, this can throw Exceptions.
+              // TODO: make this pathway non-Exception-centric.
+              val parsed = cacheable.parsed
+              // Save it in the DB:
+              dbService.run(updateScheduleStatement(json)).map { _ =>
+                logger.info(s"Saved new Schedule in the database")
+                // Once that's done, cache it:
+                _theSchedule.set(ScheduleCache(json))
+              }
+            } catch {
+              case ex: Exception => {
+                logger.error(s"Unable to parse Schedule that we received from Zambia!")
+                logger.error(response.body)
+              }
             }
           }
         }
-      }
+    }
   }
 
   def currentSchedule(): Schedule = {

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -31,6 +31,18 @@ arisia {
     # The Zoom User ID being used to create meetings, in secrets.conf:
     userId = ""
   }
+
+  zambia {
+    # The location of the "konOpas" dump on the live Zambia site:
+    # Note that this is in JSON format now, rather than the official KonOpas JSONP format, since JSON is really
+    # what we want:
+    url = "https://zambia.arisia.org/konOpas.php"
+    # The URL to connect to in order to log into Zambia, so we can pull KonOpas:
+    loginUrl = "https://zambia.arisia.org/doLogin.php"
+    # The Badge ID and Password of the Zambia user with konOpas access rights; put these in secrets.conf:
+    badgeId = ""
+    password = ""
+  }
 }
 
 # All secrets MUST go into the .gitignore'd secrets.conf file. See secrets.conf.template for details.

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -26,3 +26,8 @@ arisia.zoom.api.secret = ""
 # User Management in the Zoom account UI, clicking on the target user, and pulling the ID from the URL. There is
 # probably a way to get it from the account UI, but I haven't found it yet.
 arisia.zoom.api.userId = ""
+
+# These need to point to a Zambia user with rights to pull the KonOpas data -- see Justin directly for credentials,
+# and put them into secrets.conf:
+arisia.zambia.badgeId = ""
+arisia.zambia.password = ""


### PR DESCRIPTION
This finally crosses the line from test data into the actual live Schedule.

Note that the schedule requires a logged-in KonOpas session, so you need a Zambia badge ID and password to do this in your development environment. We have set up a Remote "member" specifically for this automation -- see Justin for the credentials.

Fixes #63 