### PR TITLE
Add docker as an option for the database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ environment this may not contain any secrets, but it is not
 unusual for it to contain an embedded password, so it is
 generally considered a secret.)
 
+###### Alternatively to installing postgres, use the docker file
+
+You need to already have docker (and docker-compose, which comes with it)
+on your machine. Then you can run `docker-compose up -d` and it will
+spawn a postgres server running on localhost:5432 for you. The connection
+string for this db is commented out in the `secrets.conf.template` file.
+
+Note: this will not work if you have something running at 5432 already.
+
 #### Running the System
 
 At the moment, the backend and frontend are not connected to

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -11,6 +11,8 @@ play.http.secret.key="[long string of characters here]"
 #
 # This should point to the site database, which should exist but otherwise starts out empty.
 db.default.url = "<JDBC URL for Postgres DB>"
+# for use with the docker container
+# db.default.url = "jdbc:postgresql://127.0.0.1:5432/arisia?user=admin&password=admin"
 
 # Put your own login here in dev environments, to allow access for yourself:
 arisia.allow.logins = []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  postgres:
+    image: postgres:13
+    container_name: arisia-postgres
+    ports:
+      - 5432:5432
+    environment: 
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_DB=arisia
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:


### PR DESCRIPTION
This means you don't have to maintain your own postgres installation locally!

Instructions are in the readme.