### PR TITLE
The backend can now end Zoom meetings

### DIFF
--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -46,7 +46,8 @@ GET     /admin/manageEarlyAccess          arisia.controllers.AdminController.man
 POST    /admin/manageEarlyAccess          arisia.controllers.AdminController.addEarlyAccess()
 DELETE  /admin/manageEarlyAccess/:name    arisia.controllers.AdminController.removeEarlyAccess(name)
 # This is mainly internal, for testing; we might add a UI if we find a use for it, but don't do that casually:
-POST    /admin/startAdHocMeeting     arisia.controllers.AdminController.startMeeting()
+POST    /admin/meeting               arisia.controllers.AdminController.startMeeting()
+DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeting(meetingId)
 # Note the non-standard path, which is configured in application.conf, so that frontend
 # can own /assets
 GET     /admin/assets/*file          controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
Took a bit of trial and error to figure out the correct way to do this, but it seems to be working.

Still only available to Admins via Swagger.

Improved the error handling of startMeeting() a little.