### PR TITLE
Fix logging

### DIFF
--- a/arisia-remote/conf/logback.xml
+++ b/arisia-remote/conf/logback.xml
@@ -8,7 +8,7 @@
     <encoder>
       <charset>UTF-8</charset>
       <pattern>
-        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+        %d{yyyy-MM-dd HH:mm:ss} -- %-5level-- :: %logger{36} :: %X{akkaSource} %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -35,7 +35,7 @@
   <logger name="arisia" level="DEBUG" />
 
   <root level="WARN">
-    <!--<appender-ref ref="ASYNCFILE" />-->
+    <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
 


### PR DESCRIPTION
Figured out that the reason we weren't writing anything to `application.log` was that the line to invoke that was commented out in the original template we started from. Uncommenting that sends stuff to the log as expected.

Also, the original template was writing all of the console coloring to the log file, which is silly: it just causes problems there. So reformatted the output-file stuff to read better from the file.