### PR TITLE
Small tweaks to how we manage time

### DIFF
--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -5,8 +5,8 @@ import arisia.admin.{AdminServiceImpl, AdminService}
 import arisia.auth.{LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
 import com.softwaremill.macwire.wire
-import arisia.schedule.{ScheduleServiceImpl, ScheduleService, StarService, StarServiceImpl}
-import arisia.timer.{TimerServiceImpl, Ticker, TimerService, TickerImpl}
+import arisia.schedule.{ScheduleServiceImpl, ScheduleService, StarServiceImpl, StarService}
+import arisia.timer.{TimerService, TimeServiceImpl, TimerServiceImpl, TimeService, Ticker, TickerImpl}
 import play.api.Configuration
 import play.api.libs.ws.WSClient
 
@@ -26,6 +26,7 @@ trait GeneralModule {
   lazy val loginService: LoginService = wire[LoginServiceImpl]
   lazy val dbService: DBService = wire[DBServiceImpl]
   lazy val ticker: Ticker = wire[TickerImpl]
+  lazy val timeService: TimeService = wire[TimeServiceImpl]
   lazy val timerService: TimerService = wire[TimerServiceImpl]
   lazy val adminService: AdminService = wire[AdminServiceImpl]
 }

--- a/arisia-remote/app/arisia/timer/TimeService.scala
+++ b/arisia-remote/app/arisia/timer/TimeService.scala
@@ -1,0 +1,14 @@
+package arisia.timer
+
+import java.time.Instant
+
+/**
+ * This is a thin layer around the system clock, so that we can potentially replace it for unit testing later.
+ */
+trait TimeService {
+  def now(): Instant
+}
+
+class TimeServiceImpl() extends TimeService {
+  def now(): Instant = Instant.now()
+}

--- a/arisia-remote/app/arisia/timer/TimerService.scala
+++ b/arisia-remote/app/arisia/timer/TimerService.scala
@@ -2,7 +2,7 @@ package arisia.timer
 
 import akka.actor.Cancellable
 import arisia.schedule.ScheduleService
-import play.api.Logging
+import play.api.{Logging, Configuration}
 
 import scala.concurrent.duration._
 
@@ -20,8 +20,12 @@ trait TimerService {
 
 class TimerServiceImpl(
   ticker: Ticker,
-  scheduleService: ScheduleService
+  scheduleService: ScheduleService,
+  config: Configuration
 ) extends TimerService with Logging {
+
+  lazy val initialDelay = config.get[FiniteDuration]("arisia.timer.initial.delay")
+  lazy val interval = config.get[FiniteDuration]("arisia.timer.interval")
 
   class Runner() extends Runnable {
     // This is called on every "tick":
@@ -34,8 +38,7 @@ class TimerServiceImpl(
   var _cancellable: Option[Cancellable] = None
 
   def init(): Unit = {
-    // TODO: make the durations configurable
-    _cancellable = Some(ticker.scheduleAtFixedRate(10.seconds, 5.minutes)(new Runner()))
+    _cancellable = Some(ticker.scheduleAtFixedRate(initialDelay, interval)(new Runner()))
   }
 
   def shutdown(): Unit = {

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -32,6 +32,11 @@ arisia {
     userId = ""
   }
 
+  timer {
+    initial.delay = 10s
+    interval = 5m
+  }
+
   zambia {
     # The location of the "konOpas" dump on the live Zambia site:
     # Note that this is in JSON format now, rather than the official KonOpas JSONP format, since JSON is really


### PR DESCRIPTION
This is mainly for testability, in the hope that we might have a chance to write unit tests. Let's not hardcode `Instant.now()` all over the place.

Also, made the Timer strobe configurable -- I'm not yet certain what settings we will want in the running site.