### PR TITLE
Progress towards automated Zoom management

### DIFF
--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -5,7 +5,7 @@ import arisia.admin.{AdminServiceImpl, AdminService}
 import arisia.auth.{LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
 import com.softwaremill.macwire.wire
-import arisia.schedule.{ScheduleServiceImpl, ScheduleService, StarServiceImpl, StarService}
+import arisia.schedule.{ScheduleService, ScheduleQueueService, ScheduleServiceImpl, StarService, StarServiceImpl, ScheduleQueueServiceImpl}
 import arisia.timer.{TimerService, TimeServiceImpl, TimerServiceImpl, TimeService, Ticker, TickerImpl}
 import play.api.Configuration
 import play.api.libs.ws.WSClient
@@ -21,12 +21,13 @@ trait GeneralModule {
   def wsClient: WSClient
   def actorSystem: ActorSystem
 
+  lazy val adminService: AdminService = wire[AdminServiceImpl]
+  lazy val dbService: DBService = wire[DBServiceImpl]
+  lazy val loginService: LoginService = wire[LoginServiceImpl]
+  lazy val scheduleQueueService: ScheduleQueueService = wire[ScheduleQueueServiceImpl]
   lazy val scheduleService: ScheduleService = wire[ScheduleServiceImpl]
   lazy val starService: StarService = wire[StarServiceImpl]
-  lazy val loginService: LoginService = wire[LoginServiceImpl]
-  lazy val dbService: DBService = wire[DBServiceImpl]
   lazy val ticker: Ticker = wire[TickerImpl]
   lazy val timeService: TimeService = wire[TimeServiceImpl]
   lazy val timerService: TimerService = wire[TimerServiceImpl]
-  lazy val adminService: AdminService = wire[AdminServiceImpl]
 }

--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -1,7 +1,7 @@
 package arisia
 
 import akka.actor.ActorSystem
-import arisia.admin.{AdminServiceImpl, AdminService}
+import arisia.admin.{RoomService, AdminServiceImpl, AdminService, RoomServiceImpl}
 import arisia.auth.{LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
 import com.softwaremill.macwire.wire
@@ -24,6 +24,7 @@ trait GeneralModule {
   lazy val adminService: AdminService = wire[AdminServiceImpl]
   lazy val dbService: DBService = wire[DBServiceImpl]
   lazy val loginService: LoginService = wire[LoginServiceImpl]
+  lazy val roomService: RoomService = wire[RoomServiceImpl]
   lazy val scheduleQueueService: ScheduleQueueService = wire[ScheduleQueueServiceImpl]
   lazy val scheduleService: ScheduleService = wire[ScheduleServiceImpl]
   lazy val starService: StarService = wire[StarServiceImpl]

--- a/arisia-remote/app/arisia/admin/RoomService.scala
+++ b/arisia-remote/app/arisia/admin/RoomService.scala
@@ -1,0 +1,58 @@
+package arisia.admin
+
+import arisia.db.DBService
+import arisia.models.ZoomRoom
+import play.api.Logging
+import doobie._
+import doobie.implicits._
+
+import scala.concurrent.Future
+
+/**
+ * Management CRUD for Zoom Rooms.
+ */
+trait RoomService {
+  def getRooms(): Future[List[ZoomRoom]]
+  def addRoom(room: ZoomRoom): Future[Int]
+  def editRoom(room: ZoomRoom): Future[Int]
+}
+
+class RoomServiceImpl(
+  dbService: DBService
+) extends RoomService with Logging
+{
+  def getRooms(): Future[List[ZoomRoom]] =
+    dbService.run(
+      sql"""
+            SELECT did, display_name, zoom_id, zambia_name, manual, webinar
+              FROM zoom_rooms"""
+        .query[ZoomRoom]
+        .to[List]
+    )
+
+  def addRoom(room: ZoomRoom): Future[Int] =
+    dbService.run(
+      sql"""
+            INSERT INTO zoom_rooms
+            (display_name, zoom_id, zambia_name, manual, webinar)
+            VALUES
+            (${room.displayName}, ${room.zoomId}, ${room.zambiaName}, ${room.isManual}, ${room.isWebinar})
+           """
+        .update
+        .run
+    )
+
+  def editRoom(room: ZoomRoom): Future[Int] =
+    dbService.run(
+      sql"""
+           UPDATE zoom_rooms
+              SET display_name = ${room.displayName},
+                  zoom_id = ${room.zoomId},
+                  zambia_name = ${room.zambiaName},
+                  manual = ${room.isManual},
+                  webinar = ${room.isWebinar}
+            WHERE did = ${room.id}"""
+        .update
+        .run
+    )
+}

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -1,8 +1,8 @@
 package arisia.controllers
 
-import arisia.admin.AdminService
+import arisia.admin.{RoomService, AdminService}
 import arisia.auth.LoginService
-import arisia.models.{LoginName, LoginUser, Permissions, LoginId}
+import arisia.models.{LoginUser, LoginId, Permissions, ZoomRoom, LoginName}
 import arisia.zoom.ZoomService
 import play.api.Logging
 import play.api.mvc._
@@ -18,7 +18,8 @@ class AdminController (
   val controllerComponents: ControllerComponents,
   adminService: AdminService,
   loginService: LoginService,
-  zoomService: ZoomService
+  zoomService: ZoomService,
+  roomService: RoomService
 )(
   implicit ec: ExecutionContext
 ) extends BaseController
@@ -69,6 +70,8 @@ class AdminController (
     }
   }
 
+  def superAdminsOnly(f: AdminInfo => Result): EssentialAction = superAdminsOnlyAsync(info => Future.successful(f(info)))
+
   def home(): EssentialAction = adminsOnly { info =>
     Ok(arisia.views.html.adminHome(info.permissions))
   }
@@ -78,6 +81,69 @@ class AdminController (
       "username" -> nonEmptyText
     )(LoginId.apply)(LoginId.unapply)
   )
+
+  /* ********************
+   *
+   * Zoom Room CRUD
+   */
+
+  val roomForm = Form(
+    mapping(
+      "id" -> number,
+      "displayName" -> nonEmptyText,
+      "zoomId" -> nonEmptyText,
+      "zambiaName" -> nonEmptyText,
+      "isManual" -> boolean,
+      "isWebinar" -> boolean
+    )(ZoomRoom.apply)(ZoomRoom.unapply)
+  )
+
+  def manageZoomRooms(): EssentialAction = superAdminsOnlyAsync { info =>
+    implicit val request = info.request
+
+    roomService.getRooms().map { rooms =>
+      Ok(arisia.views.html.manageZoomRooms(rooms))
+    }
+  }
+
+  def createRoom(): EssentialAction = superAdminsOnly { info =>
+    implicit val request = info.request
+
+    Ok(arisia.views.html.editRoom(roomForm.fill(ZoomRoom.empty)))
+  }
+  def showEditRoom(id: Int): EssentialAction = superAdminsOnlyAsync { info =>
+    implicit val request = info.request
+
+    roomService.getRooms().map { rooms =>
+      rooms.find(_.id == id) match {
+        case Some(room) => Ok(arisia.views.html.editRoom(roomForm.fill(room)))
+        case _ => BadRequest(s"$id isn't a known Room!")
+      }
+    }
+  }
+
+  def roomModified(): EssentialAction = superAdminsOnlyAsync { info =>
+    implicit val request = info.request
+
+    roomForm.bindFromRequest().fold(
+      formWithErrors => {
+        // TODO: actually display the error!
+        Future.successful(BadRequest(arisia.views.html.editRoom(formWithErrors)))
+      },
+      room => {
+        val fut =
+          if (room.id == 0) {
+            roomService.addRoom(room)
+          } else {
+            roomService.editRoom(room)
+          }
+
+        fut.map { _ =>
+          Redirect(arisia.controllers.routes.AdminController.manageZoomRooms())
+        }
+      }
+    )
+  }
 
   /* ********************
    *

--- a/arisia-remote/app/arisia/models/ProgramItem.scala
+++ b/arisia-remote/app/arisia/models/ProgramItem.scala
@@ -53,7 +53,9 @@ object ProgramItemTime {
   }
 }
 
-case class ProgramItemTimestamp(t: Instant)
+case class ProgramItemTimestamp(t: Instant) {
+  def toLong: Long = t.toEpochMilli
+}
 object ProgramItemTimestamp {
   implicit val reads: Reads[ProgramItemTimestamp] =
     JsUtils.stringReads(str => new ProgramItemTimestamp(Instant.parse(str)))

--- a/arisia-remote/app/arisia/models/ZoomRoom.scala
+++ b/arisia-remote/app/arisia/models/ZoomRoom.scala
@@ -1,0 +1,16 @@
+package arisia.models
+
+/**
+ * Represents the mapping from a Zoom Meeting/Webinar to our semantics.
+ */
+case class ZoomRoom(
+  id: Int,
+  displayName: String,
+  zoomId: String,
+  zambiaName: String,
+  isManual: Boolean,
+  isWebinar: Boolean
+)
+object ZoomRoom {
+  val empty = ZoomRoom(0, "", "", "", false, false)
+}

--- a/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
@@ -1,0 +1,92 @@
+package arisia.schedule
+
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+
+import arisia.db.DBService
+import arisia.models.{Schedule, ProgramItem}
+import arisia.timer.TimeService
+import arisia.util.Done
+import play.api.Logging
+import doobie._
+import doobie.implicits._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * This manages the Schedule Queue and Running Items Queue.
+ */
+trait ScheduleQueueService {
+  def setSchedule(schedule: Schedule): Future[Done]
+  def checkQueues(): Unit
+}
+
+class ScheduleQueueServiceImpl(
+  dbService: DBService,
+  time: TimeService
+)(
+  implicit ec: ExecutionContext
+) extends ScheduleQueueService with Logging
+{
+  /**
+   * The queue of Program Items yet to start.
+   */
+  val _scheduleQueue: AtomicReference[List[ProgramItem]] = new AtomicReference(List.empty)
+  /**
+   * The timestamp of when we most recently processed the queue.
+   *
+   * We use -1 to signify "not initialized". 0 means "has never been run".
+   */
+  val _scheduleCursor: AtomicLong = new AtomicLong(-1L)
+
+  def fetchCursorFromDatabase(): Future[Done] = {
+    dbService.run(
+      sql"""SELECT value
+              FROM text_files
+             WHERE name = 'scheduleStrobeTime'"""
+        .query[Long]
+        .option
+    ).map { cursorOpt =>
+      val cursor: Long = cursorOpt.getOrElse(0)
+      _scheduleCursor.set(cursor)
+      Done
+    }
+  }
+
+  def setSchedule(schedule: Schedule): Future[Done] = {
+    // Make sure that the schedule cursor is loaded before we try to compute the queue:
+    logger.info(s"Setting the Schedule Queue...")
+    val dbFut =
+      if (_scheduleCursor.get() == -1L) {
+        fetchCursorFromDatabase()
+      } else {
+        Future.successful(Done)
+      }
+    dbFut.map { _ =>
+      val queue =
+        schedule
+          .program
+          .filter { item =>
+            // Only bother with items that have known times, and that time is after our last processing time:
+            item.timestamp match {
+              case Some(ts) if (ts.toLong > _scheduleCursor.get()) => true
+              case _ => false
+            }
+          }
+          // TODO: filter out non-Zoom items like YouTube videos, based on their tags
+          .sortBy(_.timestamp.get.toLong)
+
+      // TODO: in theory, we should check that there are no overlapping items in a given room
+
+      _scheduleQueue.set(queue)
+      logger.info(s"Schedule Queue updated -- ${queue.length} items remaining")
+      Done
+    }
+  }
+
+  /**
+   * This is called periodically by the Timer. It checks whether there are Zoom meetings that we need to start.
+   */
+  def checkQueues(): Unit = {
+
+  }
+}

--- a/arisia-remote/app/arisia/schedule/ScheduleService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleService.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.DurationConverters._
 import scala.concurrent.duration._
 import arisia.db.DBService
-import arisia.models.{ProgramItemTime, ProgramItem, ProgramItemTimestamp, Schedule, ProgramItemId}
+import arisia.models.{ProgramItemTime, ProgramItem, ProgramItemTimestamp, Schedule, ProgramItemId, ProgramItemTitle}
 import arisia.timer.TimerService
 import arisia.util.Done
 import doobie._
@@ -90,13 +90,14 @@ class ScheduleServiceImpl(
       base.program
         // TODO: filter so this only happens for the Zoom rooms
         .map { item =>
-          val title = s""
+          val prepTitle = item.title.map(t => ProgramItemTitle(s"Prep - ${t.v}"))
           val itemStart = item.when
           val prepStart = itemStart.minus(schedulePrepStart.toJava)
           val prepTime = item.time.map(time => ProgramItemTime(time.t.minus(schedulePrepStart.toJava)))
           val zoomEnd = itemStart.plus(item.duration.toJava)
           item.copy(
             id = ProgramItemId(item.id.v + "-prep"),
+            title = prepTitle,
             prepFor = Some(item.id),
             time = prepTime,
             timestamp = Some(ProgramItemTimestamp(prepStart)),

--- a/arisia-remote/app/arisia/schedule/ScheduleService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleService.scala
@@ -1,11 +1,12 @@
 package arisia.schedule
 
-import java.time.{LocalDateTime, ZoneId, Instant}
+import java.time.{LocalDateTime, Instant, ZoneId, LocalTime}
 import java.util.concurrent.atomic.AtomicReference
 
+import scala.jdk.DurationConverters._
 import scala.concurrent.duration._
 import arisia.db.DBService
-import arisia.models.{Schedule, ProgramItemTimestamp}
+import arisia.models.{ProgramItemTime, ProgramItem, ProgramItemTimestamp, Schedule, ProgramItemId}
 import arisia.timer.TimerService
 import arisia.util.Done
 import doobie._
@@ -33,6 +34,10 @@ class ScheduleServiceImpl(
   implicit ec: ExecutionContext
 ) extends ScheduleService with Logging {
 
+  lazy val schedulePrepStart = config.get[FiniteDuration]("arisia.schedule.prep.start")
+  lazy val schedulePrepStop = config.get[FiniteDuration]("arisia.schedule.prep.end")
+  lazy val prepMins: Long = schedulePrepStart.toMinutes
+
   lazy val zambiaRefreshInterval = config.get[FiniteDuration]("arisia.zambia.refresh.interval")
   lazy val zambiaUrl = config.get[String]("arisia.zambia.url")
   lazy val zambiaLoginUrl = config.get[String]("arisia.zambia.loginUrl")
@@ -50,35 +55,69 @@ class ScheduleServiceImpl(
    */
   lazy val arisiaZone: ZoneId = ZoneId.of("EST", ZoneId.SHORT_IDS)
 
-  case class ScheduleCache(jsonStr: String) {
-    lazy val parsed: Schedule = {
-      // TODO: make this cope with failure!
-      val originalSchedule = Json.parse(jsonStr).as[Schedule]
-      // We are enhancing the Zambia data with pre-calculated timestamps for each program item, to ease the effort
-      // on the frontend side:
-      val itemsWithTimestamps = originalSchedule.program.map { item =>
-        val instant = for {
-          date <- item.date
-          time <- item.time
-          dateTime = LocalDateTime.of(date.d, time.t)
-          zoned = dateTime.atZone(arisiaZone)
-        }
-          yield ProgramItemTimestamp(zoned.toInstant)
-        item.copy(timestamp = instant)
+  def parseSchedule(jsonStr: String): Schedule = {
+    // TODO: make this cope with failure!
+    val originalSchedule = Json.parse(jsonStr).as[Schedule]
+    // We are enhancing the Zambia data with pre-calculated timestamps for each program item, to ease the effort
+    // on the frontend side:
+    val itemsWithTimestamps = originalSchedule.program.map { item =>
+      val instant = for {
+        date <- item.date
+        time <- item.time
+        dateTime = LocalDateTime.of(date.d, time.t)
+        zoned = dateTime.atZone(arisiaZone)
       }
-      originalSchedule.copy(program = itemsWithTimestamps)
+        yield ProgramItemTimestamp(zoned.toInstant)
+      item.copy(timestamp = instant)
     }
+    originalSchedule.copy(program = itemsWithTimestamps)
   }
 
-  // The currently-cached schedule, to serve out whenever the frontend needs it.
-  // The initial value is just there so that we have something valid while we wait to load the initial value
-  // from the DB
-  val _theSchedule: AtomicReference[ScheduleCache] =
-    new AtomicReference(ScheduleCache("{\"program\":[], \"people\": []}"))
+  val _scheduleJson: AtomicReference[String] = new AtomicReference("{\"program\":[], \"people\": []}")
 
-  def setSchedule(cache: ScheduleCache): Future[Done] = {
-    _theSchedule.set(cache)
-    queueService.setSchedule(cache.parsed)
+  // The currently-cached schedule, to serve out whenever the frontend needs it.
+  val _baseSchedule: AtomicReference[Schedule] =
+    new AtomicReference(Schedule.empty)
+
+  // An enhanced version of the schedule, with all of the prep sessions added.
+  // This is computed based on the base schedule. It is used by the Schedule Queue for knowing when to start
+  // and stop Zoom meetings, and we customize a view of this for people who have access to prep sessions.
+  val _scheduleWithPrep: AtomicReference[Schedule] =
+    new AtomicReference(Schedule.empty)
+
+  def computeScheduleWithPrep(base: Schedule): Schedule = {
+    val prepSessions =
+      base.program
+        // TODO: filter so this only happens for the Zoom rooms
+        .map { item =>
+          val title = s""
+          val itemStart = item.when
+          val prepStart = itemStart.minus(schedulePrepStart.toJava)
+          val prepTime = item.time.map(time => ProgramItemTime(time.t.minus(schedulePrepStart.toJava)))
+          val zoomEnd = itemStart.plus(item.duration.toJava)
+          item.copy(
+            id = ProgramItemId(item.id.v + "-prep"),
+            prepFor = Some(item.id),
+            time = prepTime,
+            timestamp = Some(ProgramItemTimestamp(prepStart)),
+            mins = Some(prepMins.toString),
+            zoomStart = Some(ProgramItemTimestamp(prepStart)),
+            zoomEnd = Some(ProgramItemTimestamp(zoomEnd))
+          )
+        }
+
+    logger.info(s"Computed ${prepSessions.length} prep sessions")
+
+    base.copy(
+      program = base.program ++ prepSessions
+    )
+  }
+
+  def setSchedule(cache: Schedule): Future[Done] = {
+    _baseSchedule.set(cache)
+    val withPrep = computeScheduleWithPrep(cache)
+    _scheduleWithPrep.set(withPrep)
+    queueService.setSchedule(withPrep)
   }
 
   final val scheduleRowName: String = "scheduleJson"
@@ -96,7 +135,7 @@ class ScheduleServiceImpl(
   // At boot time, load the last-known version of the schedule:
   dbService.run(loadInitialScheduleQuery).map { json =>
     logger.info(s"Schedule loaded from DB -- size ${json.length}")
-    setSchedule(ScheduleCache(json))
+    setSchedule(parseSchedule(json))
   }
 
   def logIntoZambia(): Future[Seq[WSCookie]] = {
@@ -125,20 +164,20 @@ class ScheduleServiceImpl(
         .get()
         .map { response =>
           val json = response.body
-          if (json == _theSchedule.get.jsonStr) {
+          if (json == _scheduleJson.get) {
             logger.info(s"Refresh -- schedule hasn't changed")
           } else {
             logger.info(s"Refreshed the schedule from Zambia -- size ${json.length}")
-            val cacheable = ScheduleCache(json)
             try {
               // For the moment, this can throw Exceptions.
               // TODO: make this pathway non-Exception-centric.
-              val parsed = cacheable.parsed
+              val schedule = parseSchedule(json)
               // Save it in the DB:
               dbService.run(updateScheduleStatement(json)).flatMap { _ =>
                 logger.info(s"Saved new Schedule in the database")
+                _scheduleJson.set(json)
                 // Once that's done, cache it:
-                setSchedule(ScheduleCache(json))
+                setSchedule(schedule)
               }
             } catch {
               case ex: Exception => {
@@ -152,6 +191,6 @@ class ScheduleServiceImpl(
   }
 
   def currentSchedule(): Schedule = {
-    _theSchedule.get.parsed
+    _baseSchedule.get
   }
 }

--- a/arisia-remote/app/arisia/timer/TimerService.scala
+++ b/arisia-remote/app/arisia/timer/TimerService.scala
@@ -1,8 +1,11 @@
 package arisia.timer
 
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.Cancellable
 import arisia.schedule.ScheduleService
-import play.api.{Logging, Configuration}
+import play.api.{Configuration, Logging}
 
 import scala.concurrent.duration._
 
@@ -14,34 +17,53 @@ import scala.concurrent.duration._
  * refactor all of this better later. (Possibly with a more sophisticated DI solution.)
  */
 trait TimerService {
+  def register(name: String, interval: FiniteDuration)(cb: Instant => Unit): Unit
+
   def init(): Unit
   def shutdown(): Unit
 }
 
 class TimerServiceImpl(
   ticker: Ticker,
-  scheduleService: ScheduleService,
+  time: TimeService,
   config: Configuration
 ) extends TimerService with Logging {
 
   lazy val initialDelay = config.get[FiniteDuration]("arisia.timer.initial.delay")
   lazy val interval = config.get[FiniteDuration]("arisia.timer.interval")
 
-  class Runner() extends Runnable {
-    // This is called on every "tick":
+  case class TimerEntry(
+    name: String,
+    interval: FiniteDuration,
+    cancellable: Option[Cancellable],
+    cb: Instant => Unit
+  ) extends Runnable {
     def run(): Unit = {
-      logger.info("Tick: running events")
-      scheduleService.refresh()
+      logger.info(s"Tick: running $name")
+      cb(time.now())
     }
+
+    def start(): TimerEntry = {
+      copy(
+        cancellable = Some(ticker.scheduleAtFixedRate(initialDelay, interval)(this))
+      )
+    }
+
+    def cancel(): Unit = cancellable.map(_.cancel())
   }
 
-  var _cancellable: Option[Cancellable] = None
+  val registry: AtomicReference[List[TimerEntry]] = new AtomicReference(List.empty)
 
-  def init(): Unit = {
-    _cancellable = Some(ticker.scheduleAtFixedRate(initialDelay, interval)(new Runner()))
+  def register(name: String, interval: FiniteDuration)(cb: Instant => Unit): Unit = {
+    registry.accumulateAndGet(
+      List(TimerEntry(name, interval, None, cb).start()),
+      _ ++ _
+    )
   }
+
+  def init(): Unit = {}
 
   def shutdown(): Unit = {
-    _cancellable.map(_.cancel())
+    registry.get().map(_.cancel())
   }
 }

--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -5,6 +5,7 @@
 
   @if(permissions.superAdmin) {
     <h2><a href="/admin/manageAdmins">Manage Admins</a></h2>
+    <h2><a href="/admin/rooms">Manage Zoom Rooms</a></h2>
   }
 
 <h2><a href="/admin/manageEarlyAccess">Manage Early Access</a></h2>

--- a/arisia-remote/app/arisia/views/editRoom.scala.html
+++ b/arisia-remote/app/arisia/views/editRoom.scala.html
@@ -1,0 +1,26 @@
+@(
+  roomForm: Form[arisia.models.ZoomRoom]
+)(
+  implicit request: RequestHeader, messagesProvider: MessagesProvider
+)
+
+@title = @{
+  if (roomForm.get.id == 0)
+    "Create Zoom Room"
+  else
+    s"Edit Zoom Room ${roomForm.get.displayName}"
+}
+
+@main(title) {
+  <h1>@title</h1>
+
+  @b4.horizontal.form(arisia.controllers.routes.AdminController.roomModified(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(roomForm("id"), Symbol("_label") -> "ID", Symbol("readonly") -> true)
+    @b4.text(roomForm("displayName"), Symbol("_label") -> "Display Name")
+    @b4.text(roomForm("zoomId"), Symbol("_label") -> "Zoom User ID")
+    @b4.text(roomForm("zambiaName"), Symbol("_label") -> "Zambia Room Name")
+    @b4.checkbox(roomForm("isManual"), Symbol("_label") -> "Non-Scheduled Room")
+    @b4.checkbox(roomForm("isWebinar"), Symbol("_label") -> "Zoom Webinar")
+    @b4.submit(Symbol("class") -> "btn btn-primary"){ Submit }
+  }
+}

--- a/arisia-remote/app/arisia/views/main.scala.html
+++ b/arisia-remote/app/arisia/views/main.scala.html
@@ -18,6 +18,9 @@
         <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
 
+        @* DataTables CSS *@
+        <link rel="stylesheet" href="https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css">
+
         @* Here's where we render the page title `String`. *@
         <title>@title</title>
 
@@ -33,6 +36,7 @@
         <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+        <script src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js" crossorigin="anonymous"></script>
 
         @* Admin-page JavaScript should go into main.js *@
         <script src="@routes.Assets.versioned("javascripts/main.js")" type="text/javascript"></script>

--- a/arisia-remote/app/arisia/views/manageAdmins.scala.html
+++ b/arisia-remote/app/arisia/views/manageAdmins.scala.html
@@ -8,7 +8,7 @@
   "Admin",
   "/admin/manageAdmins/"
 ) {
-  @helper.form(action = arisia.controllers.routes.AdminController.addAdmin()) {
-    @helper.inputText(newAdminForm("username"))
+  @b4.horizontal.form(arisia.controllers.routes.AdminController.addAdmin(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(newAdminForm("username"), Symbol("_label") -> "Username", Symbol("placeholder") -> "Login username from Registration")
   }
 }

--- a/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
+++ b/arisia-remote/app/arisia/views/manageEarlyAccess.scala.html
@@ -8,7 +8,7 @@
   "Early Access",
   "/admin/manageEarlyAccess/"
 ) {
-  @helper.form(action = arisia.controllers.routes.AdminController.addEarlyAccess()) {
-    @helper.inputText(newPersonForm("username"))
+  @b4.horizontal.form(arisia.controllers.routes.AdminController.addEarlyAccess(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(newPersonForm("username"), Symbol("_label") -> "Username", Symbol("placeholder") -> "Login username from Registration")
   }
 }

--- a/arisia-remote/app/arisia/views/manageZoomRooms.scala.html
+++ b/arisia-remote/app/arisia/views/manageZoomRooms.scala.html
@@ -1,0 +1,35 @@
+@(
+  rooms: List[arisia.models.ZoomRoom]
+)(
+  implicit request: RequestHeader, messagesProvider: MessagesProvider
+)
+
+@main("Manage Zoom Rooms") {
+  <h1>Manage Zoom Rooms</h1>
+
+
+  <table id="roomTable" class="display dataTable" style="width: 100%">
+      <thead>
+        <tr>
+            <th>Display Name</th>
+            <th>Zoom User ID</th>
+            <th>Zambia Room Name</th>
+            <th>Manual</th>
+            <th>Webinar</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for(room <- rooms) {
+          <tr>
+              <td>@{room.displayName}</td>
+              <td>@{room.zoomId}</td>
+              <td>@{room.zambiaName}</td>
+              <td>@{room.isManual}</td>
+              <td>@{room.isWebinar}</td>
+          </tr>
+        }
+      </tbody>
+  </table>
+
+  <a class="btn btn-primary" href="/admin/createRoom">Add another Zoom Room</a>
+}

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -21,15 +21,12 @@ arisia {
   allow.logins = []
   dev.admins = []
 
-  zoom.api {
-    # These get put into your secrets.conf in order to turn on Zoom integration:
-    key = ""
-    secret = ""
-    # JWTs are valid for one minute:
-    timeout = 60000
-    baseUrl = "https://api.zoom.us/v2"
-    # The Zoom User ID being used to create meetings, in secrets.conf:
-    userId = ""
+  schedule {
+    # Once a minute, check whether we need to start/stop Zoom sessions:
+    check.interval = 1m
+    # How many minutes before a Zoom program item does the prep session start and end:
+    prep.start = 30m
+    prep.end = 5m
   }
 
   timer {
@@ -48,6 +45,17 @@ arisia {
     # The Badge ID and Password of the Zambia user with konOpas access rights; put these in secrets.conf:
     badgeId = ""
     password = ""
+  }
+
+  zoom.api {
+    # These get put into your secrets.conf in order to turn on Zoom integration:
+    key = ""
+    secret = ""
+    # JWTs are valid for one minute:
+    timeout = 60000
+    baseUrl = "https://api.zoom.us/v2"
+    # The Zoom User ID being used to create meetings, in secrets.conf:
+    userId = ""
   }
 }
 

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -34,7 +34,6 @@ arisia {
 
   timer {
     initial.delay = 10s
-    interval = 5m
   }
 
   zambia {
@@ -44,6 +43,8 @@ arisia {
     url = "https://zambia.arisia.org/konOpas.php"
     # The URL to connect to in order to log into Zambia, so we can pull KonOpas:
     loginUrl = "https://zambia.arisia.org/doLogin.php"
+    # How often to refresh from Zambia:
+    refresh.interval = 5m
     # The Badge ID and Password of the Zambia user with konOpas access rights; put these in secrets.conf:
     badgeId = ""
     password = ""

--- a/arisia-remote/conf/evolutions/default/5.sql
+++ b/arisia-remote/conf/evolutions/default/5.sql
@@ -1,6 +1,7 @@
 -- !Ups
 
 CREATE TABLE zoom_rooms (
+  did integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
   display_name text NOT NULL,
   zoom_id text NOT NULL,
   zambia_name text DEFAULT '' NOT NULL,

--- a/arisia-remote/conf/evolutions/default/5.sql
+++ b/arisia-remote/conf/evolutions/default/5.sql
@@ -1,0 +1,22 @@
+-- !Ups
+
+CREATE TABLE zoom_rooms (
+  display_name text NOT NULL,
+  zoom_id text NOT NULL,
+  zambia_name text DEFAULT '' NOT NULL,
+  manual boolean DEFAULT FALSE NOT NULL,
+  webinar boolean DEFAULT FALSE NOT NULL
+);
+
+CREATE TABLE active_program_items (
+  program_item_id text NOT NULL,
+  zoom_meeting_id bigint NOT NULL,
+  host_url text NOT NULL,
+  attendee_url text NOT NULL
+);
+
+-- !Downs
+
+DROP TABLE zoom_rooms;
+
+DROP TABLE active_program_items;

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -45,6 +45,12 @@ DELETE  /admin/manageAdmins/:name    arisia.controllers.AdminController.removeAd
 GET     /admin/manageEarlyAccess          arisia.controllers.AdminController.manageEarlyAccess()
 POST    /admin/manageEarlyAccess          arisia.controllers.AdminController.addEarlyAccess()
 DELETE  /admin/manageEarlyAccess/:name    arisia.controllers.AdminController.removeEarlyAccess(name)
+GET     /admin/rooms                 arisia.controllers.AdminController.manageZoomRooms()
+
+GET     /admin/createRoom            arisia.controllers.AdminController.createRoom()
+GET     /admin/editRoom/:id          arisia.controllers.AdminController.showEditRoom(id: Int)
+POST    /admin/editRoom              arisia.controllers.AdminController.roomModified()
+
 # This is mainly internal, for testing; we might add a UI if we find a use for it, but don't do that casually:
 POST    /admin/meeting               arisia.controllers.AdminController.startMeeting()
 DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeting(meetingId)

--- a/arisia-remote/public/javascripts/main.js
+++ b/arisia-remote/public/javascripts/main.js
@@ -22,3 +22,8 @@ $('#remove-button').click(function(event) {
     }
   });
 });
+
+// Set up DataTables, if this page is using it:
+$(document).ready( function () {
+    $('.dataTable').DataTable();
+} );

--- a/build.sbt
+++ b/build.sbt
@@ -110,6 +110,7 @@ lazy val backend = (project in file("arisia-remote"))
       jwtPlay,
       macwireMacros,
       macwireUtil,
+      playBootstrap,
       scalactic,
       scalaTest,
       scalatestPlusPlay,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,8 @@ object Dependencies {
 
   val macwireVersion = "2.3.7"
 
+  val playBootstrapVersion = "1.6.1-P28-B4"
+
   val postgresDriverVersion = "42.2.18"
 
   val scalaTestVersion = "3.2.2"
@@ -45,6 +47,8 @@ object Dependencies {
 
   val macwireMacros = "com.softwaremill.macwire" %% "macros" % macwireVersion % "provided"
   val macwireUtil = "com.softwaremill.macwire" %% "util" % macwireVersion
+
+  val playBootstrap = "com.adrianhurt" %% "play-bootstrap" % playBootstrapVersion
 
   val scalactic = "org.scalactic" %% "scalactic" % scalaTestVersion
   val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"


### PR DESCRIPTION
Just a checkpoint, but lots of stuff going on here.

This creates the "prep" sessions for each scheduled Zoom item, based on the rules provided by Programming.  These sessions will only be visible on the schedule for people who are supposed to be in those sessions (or at least, have access for some reason).

This sets up the Schedule Queue, which will be used to create the Zoom meetings dynamically when they are supposed to start.

This finally deals with providing a reasonable model for CRUD UIs for Admin: we pull in the DataTables library for displaying stuff, and the play-bootstrap library for editing it.  It all requires a lot more boilerplate than I'd like, but it's probably easier to live with that than to indulge in a research project to improve it.