### PR TITLE
Zoom Meetings are now mostly implemented

### DIFF
--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -1,12 +1,13 @@
 package arisia
 
 import akka.actor.ActorSystem
-import arisia.admin.{RoomService, AdminServiceImpl, AdminService, RoomServiceImpl}
+import arisia.admin.{RoomServiceImpl, RoomService, AdminServiceImpl, AdminService}
 import arisia.auth.{LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
 import com.softwaremill.macwire.wire
 import arisia.schedule.{ScheduleService, ScheduleQueueService, ScheduleServiceImpl, StarService, StarServiceImpl, ScheduleQueueServiceImpl}
 import arisia.timer.{TimerService, TimeServiceImpl, TimerServiceImpl, TimeService, Ticker, TickerImpl}
+import arisia.zoom.ZoomModule
 import play.api.Configuration
 import play.api.libs.ws.WSClient
 
@@ -15,7 +16,7 @@ import scala.concurrent.ExecutionContext
 /**
  * This is the catch-all Module for instantiating services that don't really need a Module of their own.
  */
-trait GeneralModule {
+trait GeneralModule extends ZoomModule {
   implicit def executionContext: ExecutionContext
   def configuration: Configuration
   def wsClient: WSClient

--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import arisia.admin.{RoomServiceImpl, RoomService, AdminServiceImpl, AdminService}
 import arisia.auth.{LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
+import arisia.general.{LifecycleService, LifecycleServiceImpl}
 import com.softwaremill.macwire.wire
 import arisia.schedule.{ScheduleService, ScheduleQueueService, ScheduleServiceImpl, StarService, StarServiceImpl, ScheduleQueueServiceImpl}
 import arisia.timer.{TimerService, TimeServiceImpl, TimerServiceImpl, TimeService, Ticker, TickerImpl}
@@ -24,6 +25,7 @@ trait GeneralModule extends ZoomModule {
 
   lazy val adminService: AdminService = wire[AdminServiceImpl]
   lazy val dbService: DBService = wire[DBServiceImpl]
+  lazy val lifecycleService: LifecycleService = wire[LifecycleServiceImpl]
   lazy val loginService: LoginService = wire[LoginServiceImpl]
   lazy val roomService: RoomService = wire[RoomServiceImpl]
   lazy val scheduleQueueService: ScheduleQueueService = wire[ScheduleQueueServiceImpl]

--- a/arisia-remote/app/arisia/PlayComponents.scala
+++ b/arisia-remote/app/arisia/PlayComponents.scala
@@ -37,11 +37,10 @@ class PlayComponents(context: Context)
   with ControllerModule
   with GeneralModule
   with ZoomModule
+  with Logging
 {
   // When starting the application, run database evolutions and apply changes if needed:
   applicationEvolutions
-
-  timerService.init()
 
   lazy val httpFilters: Seq[EssentialFilter] = Seq(
     CORSFilter(
@@ -54,8 +53,14 @@ class PlayComponents(context: Context)
     wire[Routes]
   }
 
+  // We need to force the router into existence first -- this will force the controllers into existence, which
+  // forces the services into existence...
+  router
+  // ... after all of that is done, *then* we initialize anything that needs it:
+  logger.info(s"Initializing the lifecycle")
+  lifecycleService.init()
+
   applicationLifecycle.addStopHook { () =>
-    timerService.shutdown()
-    Future.successful(())
+    lifecycleService.shutdown()
   }
 }

--- a/arisia-remote/app/arisia/admin/AdminService.scala
+++ b/arisia-remote/app/arisia/admin/AdminService.scala
@@ -30,6 +30,10 @@ trait AdminService {
   def getEarlyAccess(): Future[List[LoginId]]
   def addEarlyAccess(id: LoginId): Future[Int]
   def removeEarlyAccess(id: LoginId): Future[Int]
+
+  def getTech(): Future[List[LoginId]]
+  def addTech(id: LoginId): Future[Int]
+  def removeTech(id: LoginId): Future[Int]
 }
 
 class AdminServiceImpl(
@@ -99,4 +103,8 @@ class AdminServiceImpl(
   def addEarlyAccess(id: LoginId): Future[Int] = earlyAccess.addMember(id)
   def removeEarlyAccess(id: LoginId): Future[Int] = earlyAccess.removeMember(id)
 
+  lazy val tech = new PermissionColumn("tech")
+  def getTech(): Future[List[LoginId]] = tech.getMembers()
+  def addTech(id: LoginId): Future[Int] = tech.addMember(id)
+  def removeTech(id: LoginId): Future[Int] = tech.removeMember(id)
 }

--- a/arisia-remote/app/arisia/admin/RoomService.scala
+++ b/arisia-remote/app/arisia/admin/RoomService.scala
@@ -1,7 +1,7 @@
 package arisia.admin
 
 import arisia.db.DBService
-import arisia.models.ZoomRoom
+import arisia.models.{ZoomRoom, ProgramItemLoc}
 import play.api.Logging
 import doobie._
 import doobie.implicits._
@@ -15,6 +15,8 @@ trait RoomService {
   def getRooms(): Future[List[ZoomRoom]]
   def addRoom(room: ZoomRoom): Future[Int]
   def editRoom(room: ZoomRoom): Future[Int]
+
+  def getRoomForZambia(loc: ProgramItemLoc): Future[Option[ZoomRoom]]
 }
 
 class RoomServiceImpl(
@@ -55,4 +57,14 @@ class RoomServiceImpl(
         .update
         .run
     )
+
+  def getRoomForZambia(loc: ProgramItemLoc): Future[Option[ZoomRoom]] = {
+    dbService.run(
+      sql"""
+            SELECT did, display_name, zoom_id, zambia_name, manual, webinar
+              FROM zoom_rooms"""
+        .query[ZoomRoom]
+        .option
+    )
+  }
 }

--- a/arisia-remote/app/arisia/admin/RoomService.scala
+++ b/arisia-remote/app/arisia/admin/RoomService.scala
@@ -1,38 +1,59 @@
 package arisia.admin
 
+import java.util.concurrent.atomic.AtomicReference
+
 import arisia.db.DBService
-import arisia.models.{ZoomRoom, ProgramItemLoc}
+import arisia.general.{LifecycleItem, LifecycleService}
+import arisia.models.{ProgramItemLoc, ZoomRoom}
+import arisia.util.Done
 import play.api.Logging
 import doobie._
 import doobie.implicits._
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, ExecutionContext}
 
 /**
  * Management CRUD for Zoom Rooms.
  */
 trait RoomService {
-  def getRooms(): Future[List[ZoomRoom]]
-  def addRoom(room: ZoomRoom): Future[Int]
-  def editRoom(room: ZoomRoom): Future[Int]
+  def getRooms(): List[ZoomRoom]
+  def addRoom(room: ZoomRoom): Future[Done]
+  def editRoom(room: ZoomRoom): Future[Done]
 
   def getRoomForZambia(loc: ProgramItemLoc): Future[Option[ZoomRoom]]
 }
 
 class RoomServiceImpl(
-  dbService: DBService
-) extends RoomService with Logging
+  dbService: DBService,
+  lifecycleService: LifecycleService
+)(
+  implicit ec: ExecutionContext
+) extends RoomService with LifecycleItem with Logging
 {
-  def getRooms(): Future[List[ZoomRoom]] =
+  val _roomCache: AtomicReference[List[ZoomRoom]] = new AtomicReference(List.empty)
+
+  val lifecycleName = "RoomService"
+  lifecycleService.register(this)
+  override def init(): Future[Done] = {
+    loadRooms()
+  }
+
+  private def loadRooms(): Future[Done] = {
     dbService.run(
       sql"""
             SELECT did, display_name, zoom_id, zambia_name, manual, webinar
               FROM zoom_rooms"""
         .query[ZoomRoom]
         .to[List]
-    )
+    ).map { rooms =>
+      _roomCache.set(rooms)
+      Done
+    }
+  }
 
-  def addRoom(room: ZoomRoom): Future[Int] =
+  def getRooms(): List[ZoomRoom] = _roomCache.get()
+
+  def addRoom(room: ZoomRoom): Future[Done] =
     dbService.run(
       sql"""
             INSERT INTO zoom_rooms
@@ -42,9 +63,9 @@ class RoomServiceImpl(
            """
         .update
         .run
-    )
+    ).flatMap(_ => loadRooms())
 
-  def editRoom(room: ZoomRoom): Future[Int] =
+  def editRoom(room: ZoomRoom): Future[Done] =
     dbService.run(
       sql"""
            UPDATE zoom_rooms
@@ -56,7 +77,7 @@ class RoomServiceImpl(
             WHERE did = ${room.id}"""
         .update
         .run
-    )
+    ).flatMap(_ => loadRooms())
 
   def getRoomForZambia(loc: ProgramItemLoc): Future[Option[ZoomRoom]] = {
     dbService.run(

--- a/arisia-remote/app/arisia/auth/LoginService.scala
+++ b/arisia-remote/app/arisia/auth/LoginService.scala
@@ -3,7 +3,7 @@ package arisia.auth
 import arisia.db.DBService
 
 import scala.concurrent.duration._
-import arisia.models.{LoginName, LoginUser, Permissions, LoginId}
+import arisia.models.{LoginUser, LoginId, BadgeNumber, Permissions, LoginName}
 import doobie.free.connection.ConnectionIO
 import play.api.libs.ws.WSClient
 import doobie._
@@ -88,7 +88,9 @@ class LoginServiceImpl(
             }
           }
 
-          Some(LoginUser(LoginId(id), LoginName(badgeName)))
+          // TODO: once we've done the CM handshake, put the real badge number here:
+          // TODO: if they are Tech or Safety, mark them as potential Zoom hosts:
+          Some(LoginUser(LoginId(id), LoginName(badgeName), BadgeNumber("0"), false))
         } else {
           // TODO: this is an unexpected result. Put in an alarm!
           None

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -155,12 +155,15 @@ class AdminController (
    * For now, this is internal-only, for testing, and can only be accessed from Swagger.
    */
   def startMeeting(): EssentialAction = adminsOnlyAsync { info =>
-    zoomService.startMeeting("Ad hoc meeting").map { errorOrMeeting =>
-      errorOrMeeting match {
-        case Right(meeting) => Ok(Json.toJson(meeting).toString())
-        case Left(error) => InternalServerError(error)
-      }
-    }
+    // The below code no longer works, since we need the user Id. For now, just commenting it out, since it
+    // isn't being used:
+    ???
+//    zoomService.startMeeting("Ad hoc meeting").map { errorOrMeeting =>
+//      errorOrMeeting match {
+//        case Right(meeting) => Ok(Json.toJson(meeting).toString())
+//        case Left(error) => InternalServerError(error)
+//      }
+//    }
   }
 
   def endMeeting(meetingIdStr: String): EssentialAction = adminsOnlyAsync { info =>

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -290,4 +290,33 @@ class AdminController (
   def removeEarlyAccess(idStr: String): EssentialAction = adminsOnlyAsync {
     removePermission(idStr, _.removeEarlyAccess(_), routes.AdminController.manageEarlyAccess())
   }
+
+  /* ******************
+   *
+   * Tech staff permission
+   *
+   */
+
+  private def showManageTech()(implicit request: Request[AnyContent]) =
+    showPermissionMembers(
+      _.getTech(),
+      arisia.views.html.manageTech(_, usernameForm.fill(LoginId("")))
+    )
+
+  def manageTech(): EssentialAction = adminsOnlyAsync { info =>
+    implicit val request = info.request
+    showManageTech()
+  }
+
+  def addTech(): EssentialAction = adminsOnlyAsync {
+    addPermission(
+      _.addTech(_),
+      showManageTech()(_),
+      routes.AdminController.manageTech()
+    )
+  }
+
+  def removeTech(idStr: String): EssentialAction = adminsOnlyAsync {
+    removePermission(idStr, _.removeTech(_), routes.AdminController.manageTech())
+  }
 }

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -98,12 +98,11 @@ class AdminController (
     )(ZoomRoom.apply)(ZoomRoom.unapply)
   )
 
-  def manageZoomRooms(): EssentialAction = superAdminsOnlyAsync { info =>
+  def manageZoomRooms(): EssentialAction = superAdminsOnly { info =>
     implicit val request = info.request
 
-    roomService.getRooms().map { rooms =>
-      Ok(arisia.views.html.manageZoomRooms(rooms))
-    }
+    val rooms = roomService.getRooms()
+    Ok(arisia.views.html.manageZoomRooms(rooms))
   }
 
   def createRoom(): EssentialAction = superAdminsOnly { info =>
@@ -111,14 +110,13 @@ class AdminController (
 
     Ok(arisia.views.html.editRoom(roomForm.fill(ZoomRoom.empty)))
   }
-  def showEditRoom(id: Int): EssentialAction = superAdminsOnlyAsync { info =>
+  def showEditRoom(id: Int): EssentialAction = superAdminsOnly { info =>
     implicit val request = info.request
 
-    roomService.getRooms().map { rooms =>
-      rooms.find(_.id == id) match {
-        case Some(room) => Ok(arisia.views.html.editRoom(roomForm.fill(room)))
-        case _ => BadRequest(s"$id isn't a known Room!")
-      }
+    val rooms = roomService.getRooms()
+    rooms.find(_.id == id) match {
+      case Some(room) => Ok(arisia.views.html.editRoom(roomForm.fill(room)))
+      case _ => BadRequest(s"$id isn't a known Room!")
     }
   }
 

--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -32,7 +32,7 @@ class LoginController (
 
   def login(): EssentialAction = Action.async(controllerComponents.parsers.tolerantJson[LoginRequest]) { implicit request =>
     val req = request.body
-    loginService.checkLogin(req.id, req.password).flatMap {
+    loginService.login(req.id, req.password).flatMap {
       _ match {
         case Some(user) => {
           loginService.getPermissions(user.id).map { permissions =>

--- a/arisia-remote/app/arisia/controllers/ZoomController.scala
+++ b/arisia-remote/app/arisia/controllers/ZoomController.scala
@@ -1,7 +1,9 @@
 package arisia.controllers
 
+import arisia.models.{LoginUser, ProgramItemId}
+import arisia.schedule.ScheduleService
 import arisia.zoom.ZoomService
-import play.api.mvc.{BaseController, EssentialAction, ControllerComponents}
+import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
 
 import scala.concurrent.ExecutionContext
 
@@ -10,7 +12,8 @@ import scala.concurrent.ExecutionContext
  */
 class ZoomController(
   val controllerComponents: ControllerComponents,
-  zoomService: ZoomService
+  zoomService: ZoomService,
+  scheduleService: ScheduleService
 )(
   implicit ec: ExecutionContext
 ) extends BaseController {
@@ -21,5 +24,19 @@ class ZoomController(
     zoomService.getUsers().map { _ =>
       Ok("Got it!")
     }
+  }
+
+  def enterItem(itemStr: String): EssentialAction = Action { implicit request =>
+    val redirectOpt = for {
+      // Only logged in users are allowed to join meetings:
+      user <- LoginController.loggedInUser()
+      attendeeUrl <- scheduleService.getAttendeeUrlFor(user, ProgramItemId(itemStr))
+      // If we get here, they're allowed in:
+    }
+      yield Found(attendeeUrl)
+
+    // TODO: what should we return if this fails? This is effectively a system error: it shouldn't be possible for them
+    // to get into this state, but we should probably provide a better error.
+    redirectOpt.getOrElse(NotFound("""{"success":false, "message":"That isn't a currently-running panel"}"""))
   }
 }

--- a/arisia-remote/app/arisia/controllers/ZoomController.scala
+++ b/arisia-remote/app/arisia/controllers/ZoomController.scala
@@ -39,4 +39,18 @@ class ZoomController(
     // to get into this state, but we should probably provide a better error.
     redirectOpt.getOrElse(NotFound("""{"success":false, "message":"That isn't a currently-running panel"}"""))
   }
+
+  def enterItemAsHost(itemStr: String): EssentialAction = Action { implicit request =>
+    val redirectOpt = for {
+      // Only logged in users are allowed to join meetings:
+      user <- LoginController.loggedInUser()
+      hostUrl <- scheduleService.getHostUrlFor(user, ProgramItemId(itemStr))
+      // If we get here, they're allowed in:
+    }
+      yield Found(hostUrl)
+
+    // TODO: what should we return if this fails? This is effectively a system error: it shouldn't be possible for them
+    // to get into this state, but we should probably provide a better error.
+    redirectOpt.getOrElse(NotFound("""{"success":false, "message":"That isn't a currently-running panel"}"""))
+  }
 }

--- a/arisia-remote/app/arisia/general/LifecycleService.scala
+++ b/arisia-remote/app/arisia/general/LifecycleService.scala
@@ -8,7 +8,6 @@ import play.api.Logging
 import scala.concurrent.{Future, ExecutionContext}
 
 trait LifecycleItem {
-  def lifecycleService: LifecycleService
   def lifecycleName: String
   def init(): Future[Done] = { Future.successful(Done) }
   def shutdown(): Future[Done] = { Future.successful(Done) }

--- a/arisia-remote/app/arisia/general/LifecycleService.scala
+++ b/arisia-remote/app/arisia/general/LifecycleService.scala
@@ -1,0 +1,60 @@
+package arisia.general
+
+import java.util.concurrent.atomic.AtomicReference
+
+import arisia.util.Done
+import play.api.Logging
+
+import scala.concurrent.Future
+
+trait LifecycleItem {
+  def lifecycleService: LifecycleService
+  def lifecycleName: String
+  def init(): Future[Done] = { Future.successful(Done) }
+  def shutdown(): Future[Done] = { Future.successful(Done) }
+}
+
+/**
+ * Provides a very simplistic lifecycle abstraction, so that things can be initialized and terminated in an
+ * orderly way.
+ *
+ * This is nowhere near a proper lifecycle mechanism (Querki's Ecology system has a much more fully-fledged version
+ * of this), but it should hopefully suffice for our needs. Note that it does not provide any sort of initialization
+ * order management! Init and shutdown order is basically random, so don't count on this for much.
+ *
+ * Services that want to use this should extend LifecycleItem, and register themselves here in their *constructor*.
+ *
+ * Note that it is quite possble that we should instead be using Play's own lifecycle-management system, but that is
+ * *way* more complicated, so we're keeping this simple for now.
+ */
+trait LifecycleService {
+  def register(item: LifecycleItem): Unit
+
+  def init(): Future[Done]
+  def shutdown(): Future[Done]
+}
+
+class LifecycleServiceImpl(
+
+) extends LifecycleService with Logging {
+
+  val _items: AtomicReference[Set[LifecycleItem]] = new AtomicReference(Set.empty)
+
+  def register(item: LifecycleItem): Unit = {
+    logger.info(s"Registering LifecycleItem ${item.lifecycleName}")
+    _items.accumulateAndGet(Set(item), _ ++ _)
+  }
+
+  def init(): Future[Done] = {
+    _items.get().foldLeft(Future.successful(Done)) { (_, item) =>
+      logger.info(s"Initializing ${item.lifecycleName}")
+      item.init()
+    }
+  }
+  def shutdown(): Future[Done] = {
+    _items.get().foldLeft(Future.successful(Done)) { (_, item) =>
+      logger.info(s"Shutting down ${item.lifecycleName}")
+      item.shutdown()
+    }
+  }
+}

--- a/arisia-remote/app/arisia/models/LoginUser.scala
+++ b/arisia-remote/app/arisia/models/LoginUser.scala
@@ -9,9 +9,14 @@ object LoginId extends StdStringUtils(new LoginId(_))
 case class LoginName(v: String) extends StdString
 object LoginName extends StdStringUtils(new LoginName(_))
 
+case class BadgeNumber(v: String) extends StdString
+object BadgeNumber extends StdStringUtils(new BadgeNumber(_))
+
 case class LoginUser(
   id: LoginId,
-  name: LoginName
+  name: LoginName,
+  badgeNumber: BadgeNumber,
+  zoomHost: Boolean
 )
 object LoginUser {
   implicit val fmt: Format[LoginUser] = Json.format

--- a/arisia-remote/app/arisia/models/Permissions.scala
+++ b/arisia-remote/app/arisia/models/Permissions.scala
@@ -10,10 +10,10 @@ package arisia.models
  * @param admin Permits access to the Admin pages
  * @param earlyAccess Allows this user to log into the site before we open it to all current members
  */
-case class Permissions(superAdmin: Boolean, admin: Boolean, earlyAccess: Boolean) {
-  lazy val hasEarlyAccess = superAdmin || admin || earlyAccess
+case class Permissions(superAdmin: Boolean, admin: Boolean, earlyAccess: Boolean, tech: Boolean) {
+  lazy val hasEarlyAccess = superAdmin || admin || earlyAccess || tech
 }
 
 object Permissions {
-  val empty = Permissions(false, false, false)
+  val empty = Permissions(false, false, false, false)
 }

--- a/arisia-remote/app/arisia/models/ProgramItem.scala
+++ b/arisia-remote/app/arisia/models/ProgramItem.scala
@@ -27,7 +27,11 @@ object ProgramItemPersonName extends StdStringUtils(new ProgramItemPersonName(_)
 case class ProgramItemPerson(
   id: ProgramPersonId,
   name: ProgramItemPersonName
-)
+) {
+  def matches(who: LoginUser): Boolean = {
+    id.matches(who.badgeNumber)
+  }
+}
 object ProgramItemPerson {
   implicit val fmt: Format[ProgramItemPerson] = Json.format
 }

--- a/arisia-remote/app/arisia/models/ProgramPerson.scala
+++ b/arisia-remote/app/arisia/models/ProgramPerson.scala
@@ -5,7 +5,11 @@ import arisia.util._
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-case class ProgramPersonId(v: String) extends StdString
+case class ProgramPersonId(v: String) extends StdString {
+  def matches(badgeNumber: BadgeNumber): Boolean = {
+    v == badgeNumber.v
+  }
+}
 object ProgramPersonId extends StdStringUtils(new ProgramPersonId(_))
 
 /**

--- a/arisia-remote/app/arisia/models/Schedule.scala
+++ b/arisia-remote/app/arisia/models/Schedule.scala
@@ -13,6 +13,9 @@ case class Schedule(program: List[ProgramItem], people: List[ProgramPerson]) {
   // well-enough-distributed to make hash collisions unlikely. So MD5 should suffice -- we don't need to waste
   // extra cycles on SHA256 or BCrypt:
   lazy val hash: String = json.md5.hex
+  // Map of items by ID, for quicker lookup:
+  lazy val byItemId: Map[ProgramItemId, ProgramItem] =
+    program.map(item => (item.id) -> item).toMap
 }
 
 object Schedule {

--- a/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
@@ -175,6 +175,7 @@ class ScheduleQueueServiceImpl(
         _runningItemsQueue.getAndUpdate(_.tail)
         checkMeetingsToEnd(now)
       }
+      case _ => // Nothing running
     }
   }
 

--- a/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
@@ -3,15 +3,19 @@ package arisia.schedule
 import java.time.Instant
 import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 
+import arisia.admin.RoomService
 import arisia.db.DBService
-import arisia.models.{Schedule, ProgramItem}
+import arisia.models.{ProgramItem, ZoomRoom, Schedule, ProgramItemId, ProgramItemLoc}
 import arisia.timer.{TimerService, TimeService}
 import arisia.util.Done
+import arisia.zoom.ZoomService
+import arisia.zoom.models.ZoomMeeting
 import play.api.{Configuration, Logging}
 import doobie._
 import doobie.implicits._
 
 import scala.annotation.tailrec
+import scala.collection.SortedSet
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Future, ExecutionContext}
 
@@ -25,7 +29,9 @@ trait ScheduleQueueService {
 class ScheduleQueueServiceImpl(
   dbService: DBService,
   timerService: TimerService,
-  config: Configuration
+  config: Configuration,
+  roomService: RoomService,
+  zoomService: ZoomService
 )(
   implicit ec: ExecutionContext
 ) extends ScheduleQueueService with Logging
@@ -34,6 +40,9 @@ class ScheduleQueueServiceImpl(
 
   // On a regular basis, check whether we need to start/stop Zoom sessions
   timerService.register("Schedule Queue Service", queueCheckInterval)(checkQueues)
+
+  // TODO: at boot time, load the active_program_items table into the Running Items Queue, and shut down anything
+  // that needs it
 
   /**
    * The queue of Program Items yet to start.
@@ -106,7 +115,7 @@ class ScheduleQueueServiceImpl(
   /**
    * This is called periodically by the Timer. It checks whether there are Zoom meetings that we need to start.
    */
-  private def checkQueues(now: Instant): Unit = {
+  private def checkScheduleQueue(now: Instant): Unit = {
     _scheduleQueue.get().headOption match {
       // The item at the front of the queue needs to be started:
       case Some(item) if (item.zoomStart.get.toLong < now.toEpochMilli) => {
@@ -116,19 +125,71 @@ class ScheduleQueueServiceImpl(
         _scheduleQueue.getAndUpdate(_.tail)
         // On to the next
         // TODO: once we're confident it's all working right, mark this as @tailrec
-        checkQueues(now)
+        checkScheduleQueue(now)
       }
       // We're done:
       case _ => setScheduleCursor(now.toEpochMilli)
     }
   }
 
-  private def startProgramItem(item: ProgramItem): Unit = {
-    logger.info(s"Starting Program Item ${item.title.getOrElse("UNNAMED")}")
-    // TODO: look up the zoom room in the DB
-    // TODO: create the meeting, using the appropriate userid
-    // TODO: record the running meeting in the active_program_item table
-    // TODO: add the item to the Running Items Queue, for shutdown
-    // TODO: add the item to Currently Running Items, for quick access when people try to join
+  private def checkQueues(now: Instant): Unit = {
+    checkScheduleQueue(now)
+    // TODO: check the Running Items Queue
   }
+
+  private def startProgramItem(item: ProgramItem): Future[Done] = {
+    val title = item.title.map(_.v).getOrElse("UNNAMED")
+    logger.info(s"Starting Program Item $title")
+    // TODO: logging for the failure cases here:
+    for {
+      roomOpt <- roomService.getRoomForZambia(item.loc.head)
+      if (roomOpt.isDefined)
+      room = roomOpt.get
+      meetingEither <- zoomService.startMeeting(title, room.zoomId)
+      if (meetingEither.isRight)
+      Right(meeting) = meetingEither
+      _ <- recordMeetingAsActive(item, meeting)
+    }
+      yield Done
+  }
+
+
+  case class RunningItem(endAt: Instant, itemId: ProgramItemId, meeting: ZoomMeeting)
+  object RunningItem {
+    implicit val runningItemOrdering: Ordering[RunningItem] = (x: RunningItem, y: RunningItem) => {
+      val instantOrdering = implicitly[Ordering[Instant]]
+      instantOrdering.compare(x.endAt, y.endAt)
+    }
+  }
+
+  // The Running Items Queue. Note that this is automatically sorted by the end time:
+  val _runningItemsQueue: AtomicReference[SortedSet[RunningItem]] = new AtomicReference(SortedSet.empty)
+
+  // The Currently Running Items Map, which we fetch meetings from when people want to enter them:
+  val _currentlyRunningItems: AtomicReference[Map[ProgramItemId, RunningItem]] = new AtomicReference(Map.empty)
+
+  private def recordMeetingAsActive(item: ProgramItem, meeting: ZoomMeeting): Future[Int] = {
+    // Add the meeting to the Running Items Queue, so we know to shut it down:
+    val endAt = item.zoomEnd.get
+    val runningItem = RunningItem(item.zoomEnd.get.t, item.id, meeting)
+    _runningItemsQueue.accumulateAndGet(SortedSet(runningItem), _ ++ _)
+
+    // Add the meeting to the Currently Running Items Map, so people can enter it:
+    _currentlyRunningItems.accumulateAndGet(
+      Map((item.id -> runningItem)),
+      _ ++ _
+    )
+
+    // Now record it in the DB:
+    dbService.run(
+      sql"""
+           INSERT INTO active_program_items
+           (end_at, program_item_id, zoom_meeting_id, host_url, attendee_url)
+           VALUES
+           (${endAt.toLong}, ${item.id.v}, ${meeting.id}, ${meeting.start_url}, ${meeting.join_url})"""
+        .update
+        .run
+    )
+  }
+
 }

--- a/arisia-remote/app/arisia/schedule/ScheduleService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleService.scala
@@ -32,6 +32,13 @@ trait ScheduleService {
    * Note that, since we require a LoginUser, we already know by type that this isn't anonymous.
    */
   def getAttendeeUrlFor(who: LoginUser, which: ProgramItemId): Option[String]
+
+  /**
+   * Similar to getAttendeeUrlFor, but provides the Host URL, which has lots of special powers.
+   *
+   * Only specially-designed users (broadly speaking, Tech and Safety) have access to this.
+   */
+  def getHostUrlFor(who: LoginUser, which: ProgramItemId): Option[String]
 }
 
 class ScheduleServiceImpl(
@@ -243,5 +250,18 @@ class ScheduleServiceImpl(
         false
       }
     }
+  }
+
+
+  def getHostUrlFor(who: LoginUser, which: ProgramItemId): Option[String] = {
+    for {
+      // Is this item real?
+      item <- _baseSchedule.get.byItemId.get(which)
+      // Is the meeting running?
+      meeting <- queueService.getRunningMeeting(which)
+      // Are they a potential host?
+      if (who.zoomHost)
+    }
+      yield meeting.start_url
   }
 }

--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -8,5 +8,6 @@
     <h2><a href="/admin/rooms">Manage Zoom Rooms</a></h2>
   }
 
-<h2><a href="/admin/manageEarlyAccess">Manage Early Access</a></h2>
+  <h2><a href="/admin/manageEarlyAccess">Manage Early Access</a></h2>
+  <h2><a href="/admin/manageTech">Manage Tech</a></h2>
 }

--- a/arisia-remote/app/arisia/views/manageTech.scala.html
+++ b/arisia-remote/app/arisia/views/manageTech.scala.html
@@ -1,0 +1,14 @@
+@(people: List[arisia.models.LoginId], newPersonForm: Form[arisia.models.LoginId])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
+
+@import helper._
+
+@managePermissionTemplate(
+  people,
+  newPersonForm,
+  "Tech Staff",
+  "/admin/manageTech/"
+) {
+  @b4.horizontal.form(arisia.controllers.routes.AdminController.addTech(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(newPersonForm("username"), Symbol("_label") -> "Username", Symbol("placeholder") -> "Login username from Registration")
+  }
+}

--- a/arisia-remote/app/arisia/zoom/models/ZoomMeeting.scala
+++ b/arisia-remote/app/arisia/zoom/models/ZoomMeeting.scala
@@ -6,15 +6,13 @@ import play.api.libs.json.{Format, Json}
  * The information we get back from Zoom when we create a Meeting.
  *
  * This is not the full data structure: we are only bothering to deserialize fields that we might possibly
- * care about.
+ * care about. This is intentionally minimal, so that we can easily store this record in the DB and
+ * restore it in memory.
  */
 case class ZoomMeeting(
   id: Long,
-  topic: String,
-  created_at: String,
   start_url: String,
-  join_url: String,
-  password: String
+  join_url: String
 )
 object ZoomMeeting {
   implicit val fmt: Format[ZoomMeeting] = Json.format

--- a/arisia-remote/conf/evolutions/default/5.sql
+++ b/arisia-remote/conf/evolutions/default/5.sql
@@ -17,8 +17,12 @@ CREATE TABLE active_program_items (
   attendee_url text NOT NULL
 );
 
+ALTER TABLE permissions ADD COLUMN tech boolean DEFAULT FALSE NOT NULL;
+
 -- !Downs
 
 DROP TABLE zoom_rooms;
 
 DROP TABLE active_program_items;
+
+ALTER TABLE permissions DROP COLUMN tech;

--- a/arisia-remote/conf/evolutions/default/5.sql
+++ b/arisia-remote/conf/evolutions/default/5.sql
@@ -10,6 +10,7 @@ CREATE TABLE zoom_rooms (
 );
 
 CREATE TABLE active_program_items (
+  end_at bigint NOT NULL,
   program_item_id text NOT NULL,
   zoom_meeting_id bigint NOT NULL,
   host_url text NOT NULL,

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -35,6 +35,9 @@ GET     /api/schedule/stars          arisia.controllers.ScheduleController.getSt
 PUT     /api/schedule/stars/:which   arisia.controllers.ScheduleController.addStar(which)
 # Remove the star for the specified program item ID
 DELETE  /api/schedule/stars/:which   arisia.controllers.ScheduleController.removeStar(which)
+# Try to join a running Zoom room as an attendee
+# On success, this will redirect to the actual Zoom URL
+GET     /api/schedule/:id/zoom       arisia.controllers.ZoomController.enterItem(id)
 
 # Admin UI, separate from the attendee-facing site
 GET     /admin                       arisia.controllers.AdminController.home()

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -49,8 +49,11 @@ DELETE  /admin/manageAdmins/:name    arisia.controllers.AdminController.removeAd
 GET     /admin/manageEarlyAccess          arisia.controllers.AdminController.manageEarlyAccess()
 POST    /admin/manageEarlyAccess          arisia.controllers.AdminController.addEarlyAccess()
 DELETE  /admin/manageEarlyAccess/:name    arisia.controllers.AdminController.removeEarlyAccess(name)
-GET     /admin/rooms                 arisia.controllers.AdminController.manageZoomRooms()
+GET     /admin/manageTech            arisia.controllers.AdminController.manageTech()
+POST    /admin/manageTech            arisia.controllers.AdminController.addTech()
+DELETE  /admin/manageTech/:name      arisia.controllers.AdminController.removeTech(name)
 
+GET     /admin/rooms                 arisia.controllers.AdminController.manageZoomRooms()
 GET     /admin/createRoom            arisia.controllers.AdminController.createRoom()
 GET     /admin/editRoom/:id          arisia.controllers.AdminController.showEditRoom(id: Int)
 POST    /admin/editRoom              arisia.controllers.AdminController.roomModified()

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -38,6 +38,7 @@ DELETE  /api/schedule/stars/:which   arisia.controllers.ScheduleController.remov
 # Try to join a running Zoom room as an attendee
 # On success, this will redirect to the actual Zoom URL
 GET     /api/schedule/:id/zoom       arisia.controllers.ZoomController.enterItem(id)
+GET     /api/schedule/:id/zoomhost   arisia.controllers.ZoomController.enterItemAsHost(id)
 
 # Admin UI, separate from the attendee-facing site
 GET     /admin                       arisia.controllers.AdminController.home()


### PR DESCRIPTION
This gets Zoom meetings to the point of being mostly right.  The main feature that is missing is the correct handling of Program Participants, which is blocked on getting their badge numbers from CM.  (So I'm going to pivot to working on that next.)

Zoom meetings now get started and stopped based on the schedule.

There is now an entry point for Zoom meetings -- hit this, and if you are a logged-in user, and the meeting has started, it redirects you there.

There is now an Admin UI for managing members of Tech.  They get the `zoomhost` flag, which means that they are potential Zoom hosts.  They therefore get to see the full schedule, including prep sessions, and can enter the prep sessions.

Potential Zoom hosts can now also use the special `zoomhost` variant of the enter-meeting entry point, which redirects to the Host URL instead.  The UI should only show this entry point to potential hosts, as a second link.

Provides a new, simplistic lifecycle-management system for the backend, so we get away from the ad-hockery that was throwing errors when we hit evolutions.

We don't have Webinar handling yet.  This will look largely the same from the outside, but a lot of the internal machinery is irritatingly different.

Almost none of this is *tested* yet, mind -- I need to build some test machinery that allows us to define ad-hoc extra "schedule" items, so we can test starting, entering, and ending meetings.