### PR TITLE
Add backend for Settings

### DIFF
--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -5,7 +5,7 @@ import arisia.admin.{RoomServiceImpl, RoomService, AdminServiceImpl, AdminServic
 import arisia.auth.{CMService, CMServiceImpl, LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
 import arisia.fun.{DuckServiceImpl, DuckService}
-import arisia.general.{LifecycleServiceImpl, LifecycleService}
+import arisia.general.{LifecycleServiceImpl, LifecycleService, SettingsService, SettingsServiceImpl}
 import com.softwaremill.macwire.wire
 import arisia.schedule.{ScheduleService, ScheduleQueueService, ScheduleServiceImpl, StarService, StarServiceImpl, ScheduleQueueServiceImpl}
 import arisia.timer.{TimerService, TimeServiceImpl, TimerServiceImpl, TimeService, Ticker, TickerImpl}
@@ -33,6 +33,7 @@ trait GeneralModule extends ZoomModule {
   lazy val roomService: RoomService = wire[RoomServiceImpl]
   lazy val scheduleQueueService: ScheduleQueueService = wire[ScheduleQueueServiceImpl]
   lazy val scheduleService: ScheduleService = wire[ScheduleServiceImpl]
+  lazy val settingsService: SettingsService = wire[SettingsServiceImpl]
   lazy val starService: StarService = wire[StarServiceImpl]
   lazy val ticker: Ticker = wire[TickerImpl]
   lazy val timeService: TimeService = wire[TimeServiceImpl]

--- a/arisia-remote/app/arisia/controllers/ControllerModule.scala
+++ b/arisia-remote/app/arisia/controllers/ControllerModule.scala
@@ -24,6 +24,7 @@ trait ControllerModule extends GeneralModule with ZoomModule {
   lazy val frontendController: FrontendController = wire[FrontendController]
   lazy val loginController: LoginController = wire[LoginController]
   lazy val scheduleController: ScheduleController = wire[ScheduleController]
+  lazy val settingsController: SettingsController = wire[SettingsController]
   lazy val zoomController: ZoomController = wire[ZoomController]
 
   lazy val fakeZambiaController: FakeZambiaController = wire[FakeZambiaController]

--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -83,4 +83,5 @@ object LoginController {
       case ex: Exception => None
     }
   }
+
 }

--- a/arisia-remote/app/arisia/controllers/SettingsController.scala
+++ b/arisia-remote/app/arisia/controllers/SettingsController.scala
@@ -24,12 +24,12 @@ class SettingsController(
   }
 
   def addSettings(): EssentialAction = withLoggedInUser { userRequest =>
-    val jsonStr = userRequest.request.body.toString
-    val json = Json.parse(jsonStr)
-    val settings = json.as[Map[String, String]]
-    settingsService.addSettings(userRequest.user, settings).map { _ =>
-      NoContent
-    }
+    userRequest.request.body.asJson.map { json =>
+      val settings = json.as[Map[String, String]]
+      settingsService.addSettings(userRequest.user, settings).map { _ =>
+        NoContent
+      }
+    }.getOrElse(Future.successful(BadRequest("""{"success":"false", "message":"No JSON body found!"}""")))
   }
 
   def dropSetting(k: String): EssentialAction = withLoggedInUser { userRequest =>

--- a/arisia-remote/app/arisia/controllers/SettingsController.scala
+++ b/arisia-remote/app/arisia/controllers/SettingsController.scala
@@ -1,0 +1,40 @@
+package arisia.controllers
+
+import play.api.mvc.{Request, ControllerComponents, AnyContent, BaseController, EssentialAction, Result}
+import arisia.auth.LoginService
+import arisia.general.SettingsService
+import arisia.models.LoginUser
+import play.api.Logging
+import play.api.libs.json.Json
+
+import scala.concurrent.{Future, ExecutionContext}
+
+class SettingsController(
+  val controllerComponents: ControllerComponents,
+  val loginService: LoginService,
+  settingsService: SettingsService
+)(
+  implicit val ec: ExecutionContext
+) extends BaseController with UserFuncs with Logging {
+
+  def getSettings(): EssentialAction = withLoggedInUser { userRequest =>
+    settingsService.getSettings(userRequest.user).map { settings =>
+      Ok(Json.toJson(settings).toString())
+    }
+  }
+
+  def addSettings(): EssentialAction = withLoggedInUser { userRequest =>
+    val jsonStr = userRequest.request.body.toString
+    val json = Json.parse(jsonStr)
+    val settings = json.as[Map[String, String]]
+    settingsService.addSettings(userRequest.user, settings).map { _ =>
+      NoContent
+    }
+  }
+
+  def dropSetting(k: String): EssentialAction = withLoggedInUser { userRequest =>
+    settingsService.dropSetting(userRequest.user, k).map { _ =>
+      NoContent
+    }
+  }
+}

--- a/arisia-remote/app/arisia/controllers/UserFuncs.scala
+++ b/arisia-remote/app/arisia/controllers/UserFuncs.scala
@@ -1,0 +1,22 @@
+package arisia.controllers
+
+import arisia.models.LoginUser
+import play.api.mvc.{Request, AnyContent, BaseController, EssentialAction, Result}
+
+import scala.concurrent.Future
+
+trait UserFuncs extends BaseController {
+
+  case class UserRequest(user: LoginUser, request: Request[AnyContent])
+
+  def withLoggedInUser(f: UserRequest => Future[Result]): EssentialAction = Action.async { implicit request =>
+    LoginController.loggedInUser() match {
+      case Some(user) => {
+        val userRequest = UserRequest(user, request)
+        f(userRequest)
+      }
+      case _ => Future.successful(Forbidden(s"""{"success":false, "message":"You're not logged in! Please log in and try again."}"""))
+    }
+  }
+
+}

--- a/arisia-remote/app/arisia/fun/DuckService.scala
+++ b/arisia-remote/app/arisia/fun/DuckService.scala
@@ -3,7 +3,9 @@ package arisia.fun
 import java.util.concurrent.atomic.AtomicReference
 
 import arisia.db.DBService
+import arisia.general.{LifecycleService, LifecycleItem}
 import arisia.models.LoginId
+import arisia.util.Done
 import play.api.Logging
 import doobie._
 import doobie.implicits._
@@ -45,10 +47,17 @@ trait DuckService {
 }
 
 class DuckServiceImpl(
-  dbService: DBService
+  dbService: DBService,
+  lifecycleService: LifecycleService
 )(
   implicit ec: ExecutionContext
-) extends DuckService with Logging {
+) extends DuckService with Logging with LifecycleItem {
+
+  val lifecycleName = "DuckService"
+  lifecycleService.register(this)
+  override def init(): Future[Done] = {
+    loadDucks().map { _ => Done }
+  }
 
   // Yes, we're maintaining a high-performance cache of ducks. Why not...
   val _duckCache: AtomicReference[List[Duck]] = new AtomicReference(List.empty)

--- a/arisia-remote/app/arisia/general/SettingsService.scala
+++ b/arisia-remote/app/arisia/general/SettingsService.scala
@@ -1,0 +1,63 @@
+package arisia.general
+
+import arisia.db.DBService
+import arisia.models.LoginUser
+import play.api.Logging
+import doobie._
+import doobie.implicits._
+import scala.concurrent.{Future, ExecutionContext}
+
+trait SettingsService {
+  def getSettings(who: LoginUser): Future[Map[String, String]]
+  def addSettings(who: LoginUser, settings: Map[String, String]): Future[Int]
+  def dropSetting(who: LoginUser, which: String): Future[Int]
+}
+
+class SettingsServiceImpl(
+  dbService: DBService
+)(
+  implicit ec: ExecutionContext
+) extends SettingsService with Logging {
+  def getSettings(who: LoginUser): Future[Map[String, String]] = {
+    dbService.run(
+      sql"""
+           SELECT k, v
+             FROM user_settings
+            WHERE username = ${who.id.v}"""
+        .query[(String, String)]
+        .to[List]
+        .map(_.toMap)
+    )
+  }
+
+  def addSettings(who: LoginUser, settings: Map[String, String]): Future[Int] = {
+    // It's probably possible to do this all in one shot, but it's easier for me to get the Scala right
+    // than the SQL, and it's not a huge problem if we do a few extra calls:
+    settings.foldLeft(Future.successful(0)) { case (prev, (k, v)) =>
+      prev.flatMap { _ =>
+        dbService.run(
+          sql"""
+            INSERT INTO user_settings
+            (username, k, v)
+            VALUES
+            (${who.id.v}, $k, $v)
+            ON CONFLICT (username, k)
+            DO UPDATE SET v = $v
+           """
+            .update
+            .run
+        )
+      }
+    }
+  }
+
+  def dropSetting(who: LoginUser, which: String): Future[Int] = {
+    dbService.run(
+      sql"""
+           DELETE FROM user_settings
+            WHERE username = ${who.id.v} and k = $which"""
+        .update
+        .run
+    )
+  }
+}

--- a/arisia-remote/conf/evolutions/default/7.sql
+++ b/arisia-remote/conf/evolutions/default/7.sql
@@ -1,0 +1,12 @@
+-- !Ups
+
+CREATE TABLE user_settings (
+  username text NOT NULL,
+  k text NOT NULL,
+  v text NOT NULL,
+  PRIMARY KEY (username, k)
+);
+
+-- !Downs
+
+DROP TABLE user_settings;

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -49,6 +49,10 @@ GET     /admin/createDuck            arisia.controllers.DuckController.createDuc
 GET     /admin/editDuck/:id          arisia.controllers.DuckController.showEditDuck(id: Int)
 POST    /admin/editDuck              arisia.controllers.DuckController.duckModified()
 
+GET     /api/settings                arisia.controllers.SettingsController.getSettings()
+POST    /api/settings                arisia.controllers.SettingsController.addSettings()
+DELETE  /api/settings/:key           arisia.controllers.SettingsController.dropSetting(key)
+
 # Admin UI, separate from the attendee-facing site
 GET     /admin                       arisia.controllers.AdminController.home()
 GET     /admin/                      arisia.controllers.AdminController.home()


### PR DESCRIPTION
This is very simple, and very untested, but straightforward enough that it is fairly likely to work.

`GET /api/settings` returns a dictionary of key/value pairs for this user.
`POST /api/settings` takes a dictionary of key/value pairs, and inserts/updates them in this user's settings.
`DELETE /api/settings/{key}` removes the specified key from the user's settings.

Also: fixes a bug with the DuckService, which wasn't preloading its cache, and therefore was spuriously returning an empty set.

Also: a bit of refactoring to make it easier to declare functions that only work for logged-in users.

Fixes #147 