### PR TITLE
Beginnings of the Schedule Test system

### DIFF
--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -5,7 +5,7 @@ import arisia.admin.{RoomServiceImpl, RoomService, AdminServiceImpl, AdminServic
 import arisia.auth.{CMService, CMServiceImpl, LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
 import arisia.fun.{DuckServiceImpl, DuckService}
-import arisia.general.{LifecycleServiceImpl, LifecycleService, SettingsService, SettingsServiceImpl}
+import arisia.general.{SettingsServiceImpl, LifecycleServiceImpl, DiscordServiceImpl, SettingsService, LifecycleService, DiscordService}
 import com.softwaremill.macwire.wire
 import arisia.schedule.{ScheduleService, ScheduleQueueService, ScheduleServiceImpl, StarService, StarServiceImpl, ScheduleQueueServiceImpl}
 import arisia.timer.{TimerService, TimeServiceImpl, TimerServiceImpl, TimeService, Ticker, TickerImpl}
@@ -27,6 +27,7 @@ trait GeneralModule extends ZoomModule {
   lazy val adminService: AdminService = wire[AdminServiceImpl]
   lazy val cmService: CMService = wire[CMServiceImpl]
   lazy val dbService: DBService = wire[DBServiceImpl]
+  lazy val discordService: DiscordService = wire[DiscordServiceImpl]
   lazy val duckService: DuckService = wire[DuckServiceImpl]
   lazy val lifecycleService: LifecycleService = wire[LifecycleServiceImpl]
   lazy val loginService: LoginService = wire[LoginServiceImpl]

--- a/arisia-remote/app/arisia/controllers/ControllerModule.scala
+++ b/arisia-remote/app/arisia/controllers/ControllerModule.scala
@@ -20,6 +20,7 @@ trait ControllerModule extends GeneralModule with ZoomModule {
   def configuration: Configuration
 
   lazy val adminController: AdminController = wire[AdminController]
+  lazy val discordController: DiscordController = wire[DiscordController]
   lazy val duckController: DuckController = wire[DuckController]
   lazy val frontendController: FrontendController = wire[FrontendController]
   lazy val loginController: LoginController = wire[LoginController]
@@ -28,4 +29,5 @@ trait ControllerModule extends GeneralModule with ZoomModule {
   lazy val zoomController: ZoomController = wire[ZoomController]
 
   lazy val fakeZambiaController: FakeZambiaController = wire[FakeZambiaController]
+  lazy val scheduleTestController: ScheduleTestController = wire[ScheduleTestController]
 }

--- a/arisia-remote/app/arisia/controllers/DiscordController.scala
+++ b/arisia-remote/app/arisia/controllers/DiscordController.scala
@@ -1,0 +1,26 @@
+package arisia.controllers
+
+import arisia.auth.LoginService
+import arisia.general.DiscordService
+import play.api.i18n.I18nSupport
+import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
+
+import scala.concurrent.ExecutionContext
+
+class DiscordController(
+  val controllerComponents: ControllerComponents,
+  val loginService: LoginService,
+  discordService: DiscordService
+)(
+  implicit val ec: ExecutionContext
+) extends BaseController
+  with AdminControllerFuncs
+  with I18nSupport
+{
+  // TODO: remove this test entry point
+  def test(): EssentialAction = Action.async { implicit request =>
+    discordService.getMembers().map { _ =>
+      Ok("See logs")
+    }
+  }
+}

--- a/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
@@ -1,0 +1,98 @@
+package arisia.controllers
+
+import java.time.{LocalDate, LocalTime}
+
+import arisia.auth.LoginService
+import arisia.models.{ProgramItemPersonName, ProgramItemTime, ProgramItemTag, ProgramItemDesc, ProgramItemDate, ProgramItem, ProgramItemPerson, ProgramItemId, ProgramItemLoc, ProgramItemTitle, ProgramPersonId}
+import arisia.schedule.ScheduleService
+import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
+import play.api.data._
+import play.api.data.Forms._
+import play.api.i18n.I18nSupport
+
+import scala.concurrent.{Future, ExecutionContext}
+
+case class ScheduleInput(id: String, title: String, tags: String, time: String, mins: Int, loc: String, people: String, desc: String)
+object ScheduleInput {
+  val empty = ScheduleInput("", "", "", "", 60, "", "", "")
+}
+class ScheduleTestController(
+  val controllerComponents: ControllerComponents,
+  val loginService: LoginService,
+  scheduleService: ScheduleService
+)(
+  implicit val ec: ExecutionContext
+) extends BaseController
+  with AdminControllerFuncs
+  with I18nSupport
+{
+
+  val scheduleForm = Form(
+    mapping(
+      "id" -> text,
+      "title" -> text,
+      // Comma-delimited tags
+      "tags" -> text,
+      // For now, we are assuming that date is today
+      "time" -> text,
+      "mins" -> number,
+      "loc" -> text,
+      // Comma-delimited person IDs
+      "people" -> text,
+      "desc" -> text
+    )(ScheduleInput.apply)(ScheduleInput.unapply)
+  )
+
+  def showTestScheduleInput(): EssentialAction = adminsOnly { info =>
+    implicit val request = info.request
+
+    Ok(arisia.views.html.addTestScheduleItem(scheduleForm.fill(ScheduleInput.empty)))
+  }
+
+  def addTestScheduleItem(): EssentialAction = adminsOnly { info =>
+    implicit val request = info.request
+
+    def toField[T](str: String, f: String => T): Option[T] = {
+      if (str.isEmpty)
+        None
+      else
+        Some(f(str))
+    }
+
+    scheduleForm.bindFromRequest().fold(
+      formWithErrors => BadRequest(""),
+      input => {
+        val tags: List[ProgramItemTag] = input.tags.split(',').toList.map(ProgramItemTag(_))
+        val time: Option[ProgramItemTime] =
+          if (input.time.isEmpty)
+            None
+          else
+            Some(ProgramItemTime(LocalTime.parse(input.time)))
+        val people: List[ProgramItemPerson] =
+          input.people.split(',').toList.map { id =>
+            ProgramItemPerson(
+              ProgramPersonId(id),
+              ProgramItemPersonName(s"Participant $id")
+            )
+          }
+
+        val item = ProgramItem(
+          ProgramItemId(input.id),
+          toField(input.title, ProgramItemTitle(_)),
+          tags,
+          Some(ProgramItemDate(LocalDate.now())),
+          time,
+          Some(input.mins.toString),
+          List(ProgramItemLoc(input.loc)),
+          people,
+          toField(input.desc, ProgramItemDesc(_)),
+          None, None, None, None
+        )
+
+        scheduleService.addTestItem(item)
+
+        Redirect(arisia.controllers.routes.ScheduleTestController.showTestScheduleInput())
+      }
+    )
+  }
+}

--- a/arisia-remote/app/arisia/general/DiscordService.scala
+++ b/arisia-remote/app/arisia/general/DiscordService.scala
@@ -1,0 +1,51 @@
+package arisia.general
+
+import java.util.concurrent.atomic.AtomicReference
+
+import arisia.util.Done
+import play.api.libs.ws.WSClient
+import play.api.libs.ws.ahc.AhcCurlRequestLogger
+import play.api.{Configuration, Logging, ConfigLoader}
+
+import scala.concurrent.{Future, ExecutionContext}
+
+/**
+ * This manages *some* of the ArisiaBot; other functions are managed via Python in Lambda.
+ */
+trait DiscordService {
+  def getMembers(): Future[Done]
+}
+
+class DiscordServiceImpl(
+  config: Configuration,
+  ws: WSClient
+)(
+  implicit ec: ExecutionContext
+) extends DiscordService with LifecycleItem with Logging {
+
+  def botConfig[T: ConfigLoader](suffix: String) = config.get[T](s"arisia.discord.bot.$suffix")
+  lazy val botEnabled = botConfig[Boolean]("enabled")
+  lazy val botToken = botConfig[String]("token")
+  lazy val arisiaGuildId = botConfig[String]("guildId")
+  lazy val arisianRoleId = botConfig[String]("arisianRoleId")
+
+  val lifecycleName = "DiscordService"
+
+  def getMembers(): Future[Done] = {
+    if (botEnabled) {
+      ws.url(s"https://discord.com/api/guilds/$arisiaGuildId/members")
+        .addHttpHeaders("Authorization" -> s"Bot $botToken")
+        // TODO: what are we using this for? Do we need to loop and do pagination?
+        .addQueryStringParameters("limit" -> "100")
+        .withRequestFilter(AhcCurlRequestLogger())
+        .get()
+        .map { response =>
+          println(s"Response from getMembers:\n$response\n${response.body}")
+          Done
+        }
+    } else {
+      Future.successful(Done)
+    }
+  }
+
+}

--- a/arisia-remote/app/arisia/views/addTestScheduleItem.scala.html
+++ b/arisia-remote/app/arisia/views/addTestScheduleItem.scala.html
@@ -1,0 +1,27 @@
+@(
+  scheduleForm: Form[arisia.controllers.ScheduleInput]
+)(
+  implicit request: RequestHeader, messagesProvider: MessagesProvider
+)
+
+@main("Add Test Schedule Item") {
+  <h1>Add Test Schedule Item</h1>
+
+  <p>This lets you inject a <b>fake</b> schedule item into the online schedule. It is strictly for test purposes,
+  and the item will go away when the server is next restarted. It is only here for pre-con testing, and
+  <b>MUST NOT BE USED</b> during the convention.</p>
+
+  <p>We do no validation of the inputs; if you mess it up, it will just fail.</p>
+
+  @b4.horizontal.form(arisia.controllers.routes.ScheduleTestController.addTestScheduleItem(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(scheduleForm("id"), Symbol("_label") -> "Item ID", Symbol("_help") -> "Make this a number larger than 1000")
+    @b4.text(scheduleForm("title"), Symbol("_label") -> "Title", Symbol("_help") -> "The title to show in the schedule")
+    @b4.text(scheduleForm("tags"), Symbol("_label") -> "Tags", Symbol("_help") -> "Optional comma-delimited tags")
+    @b4.text(scheduleForm("time"), Symbol("_label") -> "Start Time", Symbol("_help") -> "24-hour time: eg, 22:30 for 10:30pm")
+    @b4.text(scheduleForm("mins"), Symbol("_label") -> "Minutes", Symbol("_help") -> "How long this session runs")
+    @b4.text(scheduleForm("loc"), Symbol("_label") -> "Location", Symbol("_help") -> "Must match a Zambia Zoom room name!")
+    @b4.text(scheduleForm("people"), Symbol("_label") -> "Participant IDs", Symbol("_help") -> "Badge numbers of the panelists")
+    @b4.text(scheduleForm("desc"), Symbol("_label") -> "Description")
+    @b4.submit(Symbol("class") -> "btn btn-primary"){ Submit }
+  }
+}

--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -11,4 +11,5 @@
   <h2><a href="/admin/manageEarlyAccess">Manage Early Access</a></h2>
   <h2><a href="/admin/manageTech">Manage Tech</a></h2>
   <h2><a href="/admin/ducks">Manage Ducks</a></h2>
+  <h2><a href="/test/scheduleItem">Add Test Schedule Item</a></h2>
 }

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -49,6 +49,20 @@ arisia {
     }
   }
 
+  discord {
+    bot {
+      # Turn this on to begin processing bot events
+      # THIS IS HIGHLY DANGEROUS, and you probably don't need it in your dev environment unless you are Gail or Justin.
+      enabled = false
+      # If enabled, you will need to applicaton token in your secrets.conf. Get it from Gail or Justin if you need it.
+      token = ""
+      # Our server
+      guildId = "743094117554454599"
+      # The base-level role that is enabled for attendees
+      arisianRoleId = "759881274269237271"
+    }
+  }
+
   schedule {
     # Once a minute, check whether we need to start/stop Zoom sessions:
     check.interval = 1m

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -82,6 +82,10 @@ GET     /admin/assets/*file          controllers.Assets.versioned(path="/public"
 GET     /test/fakeschedule           arisia.controllers.FakeZambiaController.getSchedule()
 # TODO: remove
 GET     /test/zoomcall               arisia.controllers.ZoomController.test()
+# TODO: remove
+GET     /test/getDiscordMembers      arisia.controllers.DiscordController.test()
+GET     /test/scheduleItem           arisia.controllers.ScheduleTestController.showTestScheduleInput()
+POST    /test/scheduleItem           arisia.controllers.ScheduleTestController.addTestScheduleItem()
 
 # During development, get the Swagger UI at:
 #   http://localhost:9000/docs/swagger-ui/index.html?url=/admin/assets/swagger.json

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -40,3 +40,6 @@ arisia.cm.password = ""
 
 # When CM integration is not turned on, set the desired badge number for testing here:
 arisia.cm.test.user.badgeNumber = ""
+
+# The token used to authenticate the Discord bot:
+arisia.discord.bot.token = ""


### PR DESCRIPTION
This introduces a new Admin UI, that allows you to input fake program items. These exist only in-memory for the duration of this server run, and get merged into the real schedule. The point of this is to allow us to test actually *using* the schedule, with program items coming up in the near future, to ensure that things actually work as intended.

Also includes the very beginnings of backend-side Discord integration: so far, just a proof of concept that we can fetch the members of the Arisia Discord server. This will form part of the ArisiaBot, sharing the responsibilities with the Python Lambda bits.