### PR TITLE
Add Discord channels to the panel rooms

### DIFF
--- a/arisia-remote/app/arisia/admin/RoomService.scala
+++ b/arisia-remote/app/arisia/admin/RoomService.scala
@@ -41,7 +41,7 @@ class RoomServiceImpl(
   private def loadRooms(): Future[Done] = {
     dbService.run(
       sql"""
-            SELECT did, display_name, zoom_id, zambia_name, manual, webinar
+            SELECT did, display_name, zoom_id, zambia_name, discord_name, manual, webinar
               FROM zoom_rooms"""
         .query[ZoomRoom]
         .to[List]
@@ -57,9 +57,9 @@ class RoomServiceImpl(
     dbService.run(
       sql"""
             INSERT INTO zoom_rooms
-            (display_name, zoom_id, zambia_name, manual, webinar)
+            (display_name, zoom_id, zambia_name, discord_name, manual, webinar)
             VALUES
-            (${room.displayName}, ${room.zoomId}, ${room.zambiaName}, ${room.isManual}, ${room.isWebinar})
+            (${room.displayName}, ${room.zoomId}, ${room.zambiaName}, ${room.discordName}, ${room.isManual}, ${room.isWebinar})
            """
         .update
         .run
@@ -72,6 +72,7 @@ class RoomServiceImpl(
               SET display_name = ${room.displayName},
                   zoom_id = ${room.zoomId},
                   zambia_name = ${room.zambiaName},
+                  discord_name = ${room.discordName},
                   manual = ${room.isManual},
                   webinar = ${room.isWebinar}
             WHERE did = ${room.id}"""
@@ -82,8 +83,9 @@ class RoomServiceImpl(
   def getRoomForZambia(loc: ProgramItemLoc): Future[Option[ZoomRoom]] = {
     dbService.run(
       sql"""
-            SELECT did, display_name, zoom_id, zambia_name, manual, webinar
-              FROM zoom_rooms"""
+            SELECT did, display_name, zoom_id, zambia_name, discord_name, manual, webinar
+              FROM zoom_rooms
+             WHERE zambia_name = ${loc.v}"""
         .query[ZoomRoom]
         .option
     )

--- a/arisia-remote/app/arisia/controllers/ZoomController.scala
+++ b/arisia-remote/app/arisia/controllers/ZoomController.scala
@@ -75,6 +75,7 @@ class ZoomController(
       "displayName" -> nonEmptyText,
       "zoomId" -> nonEmptyText,
       "zambiaName" -> nonEmptyText,
+      "discordName" -> nonEmptyText,
       "isManual" -> boolean,
       "isWebinar" -> boolean
     )(ZoomRoom.apply)(ZoomRoom.unapply)

--- a/arisia-remote/app/arisia/models/ZoomRoom.scala
+++ b/arisia-remote/app/arisia/models/ZoomRoom.scala
@@ -8,9 +8,10 @@ case class ZoomRoom(
   displayName: String,
   zoomId: String,
   zambiaName: String,
+  discordName: String,
   isManual: Boolean,
   isWebinar: Boolean
 )
 object ZoomRoom {
-  val empty = ZoomRoom(0, "", "", "", false, false)
+  val empty = ZoomRoom(0, "", "", "", "", false, false)
 }

--- a/arisia-remote/app/arisia/views/editRoom.scala.html
+++ b/arisia-remote/app/arisia/views/editRoom.scala.html
@@ -19,6 +19,7 @@
     @b4.text(roomForm("displayName"), Symbol("_label") -> "Display Name")
     @b4.text(roomForm("zoomId"), Symbol("_label") -> "Zoom User ID")
     @b4.text(roomForm("zambiaName"), Symbol("_label") -> "Zambia Room Name")
+    @b4.text(roomForm("discordName"), Symbol("_label") -> "Discord Channel")
     @b4.checkbox(roomForm("isManual"), Symbol("_label") -> "Non-Scheduled Room")
     @b4.checkbox(roomForm("isWebinar"), Symbol("_label") -> "Zoom Webinar")
     @b4.submit(Symbol("class") -> "btn btn-primary"){ Submit }

--- a/arisia-remote/app/arisia/views/manageZoomRooms.scala.html
+++ b/arisia-remote/app/arisia/views/manageZoomRooms.scala.html
@@ -11,9 +11,11 @@
   <table id="roomTable" class="display dataTable" style="width: 100%">
       <thead>
         <tr>
+            <th>ID</th>
             <th>Display Name</th>
             <th>Zoom User ID</th>
             <th>Zambia Room Name</th>
+            <th>Discord Channel Name</th>
             <th>Manual</th>
             <th>Webinar</th>
         </tr>
@@ -21,9 +23,11 @@
       <tbody>
         @for(room <- rooms) {
           <tr>
+              <td><a href="/admin/editRoom/@{room.id}">@{room.id}</a></td>
               <td>@{room.displayName}</td>
               <td>@{room.zoomId}</td>
               <td>@{room.zambiaName}</td>
+              <td>@{room.discordName}</td>
               <td>@{room.isManual}</td>
               <td>@{room.isWebinar}</td>
           </tr>

--- a/arisia-remote/conf/evolutions/default/8.sql
+++ b/arisia-remote/conf/evolutions/default/8.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+ALTER TABLE zoom_rooms ADD COLUMN discord_name text DEFAULT '' NOT NULL;
+
+-- !Downs
+
+ALTER TABLE zoom_rooms DROP COLUMN discord_name;

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -27,6 +27,8 @@ arisia.zoom.api.secret = ""
 # This must be the ID of a user on this Zoom account. It isn't easy to find this ID -- I find it by going into
 # User Management in the Zoom account UI, clicking on the target user, and pulling the ID from the URL. There is
 # probably a way to get it from the account UI, but I haven't found it yet.
+# At this point, this is only used for testing the simple startMeeting() test endpoint, which is likely to go
+# away before terribly long. These userIds now go into the Manage Zoom Rooms Superadmin portal, not in config.
 arisia.zoom.api.userId = ""
 
 # These need to point to a Zambia user with rights to pull the KonOpas data -- see Justin directly for credentials,


### PR DESCRIPTION
If we want to be able to post automated messages, we need to be able to track how the channels correspond to the rooms.

Also, this adds the U in CRUD for the Zoom Room editing. This serves as a model for how to do that.