### PR TITLE
Fix login bugs.

### DIFF
--- a/frontend/src/app/_services/account.service.ts
+++ b/frontend/src/app/_services/account.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { tap, map, shareReplay } from 'rxjs/operators';
+import { map, shareReplay } from 'rxjs/operators';
 import { of, Observable, BehaviorSubject, ReplaySubject } from 'rxjs';
 
 import { environment } from '@environments/environment';

--- a/frontend/src/app/_services/account.service.ts
+++ b/frontend/src/app/_services/account.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { tap, map } from 'rxjs/operators';
+import { tap, map, shareReplay } from 'rxjs/operators';
 import { of, Observable, BehaviorSubject, ReplaySubject } from 'rxjs';
 
 import { environment } from '@environments/environment';
@@ -31,21 +31,27 @@ export class AccountService {
 
   // TODO: stop sending password in plain text
   login(id: string, password: string) {
-    return this.http.post<User>(`${environment.backend}/login`, {id, password}, {withCredentials: true}).pipe(
-      tap(user => {
+    const loginRequest = this.http.post<User>(`${environment.backend}/login`, {id, password}, {withCredentials: true}).pipe(
+      shareReplay(),
+    );
+    loginRequest.subscribe(
+      user => {
         this.user = user;
         this.user$.next(this.user);
-      }),
-    );
+      });
+    return loginRequest;
   }
 
   logout() {
-    return this.http.post(`${environment.backend}/logout`, {}, {withCredentials: true}).pipe(
-      tap(_ => {
+    const loginRequest = this.http.post(`${environment.backend}/logout`, {}, {withCredentials: true}).pipe(
+      shareReplay(),
+    );
+    loginRequest.subscribe(
+      user => {
         this.user = undefined;
         this.user$.next(this.user);
-      }),
-    );
+      });
+    return loginRequest;
   }
 
   getUser(badgeNumber: string) : Observable<User> {

--- a/frontend/src/app/_services/account.service.ts
+++ b/frontend/src/app/_services/account.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { tap, map } from 'rxjs/operators';
-import { of, Observable, BehaviorSubject } from 'rxjs';
+import { of, Observable, BehaviorSubject, ReplaySubject } from 'rxjs';
 
 import { environment } from '@environments/environment';
 import { User } from '@app/_models';
@@ -11,7 +11,7 @@ import { User } from '@app/_models';
 })
 export class AccountService {
   user?: User = undefined;
-  readonly user$ = new BehaviorSubject<User | undefined>(this.user);
+  readonly user$ = new ReplaySubject<User | undefined>(1);
   readonly loggedIn$!: Observable<boolean>;
 
   get loggedIn(): boolean {
@@ -19,12 +19,11 @@ export class AccountService {
   }
 
   constructor( private http: HttpClient,) {
-    this.http.get<User>(`${environment.backend}/me`, {withCredentials: true}).pipe(
-      tap(user => {
+    this.http.get<User>(`${environment.backend}/me`, {withCredentials: true}).subscribe(
+      user => {
         this.user = user;
         this.user$.next(this.user);
-      }),
-    );
+      });
     this.loggedIn$ = this.user$.pipe(
       map(user => !!user),
     );


### PR DESCRIPTION
The first bug was that we never subscribed to the "me" call in
account.service.ts. Switching from a tap to a subscribe fixed
that. The other calls currently have subscribers, but I'm going to
learn how to multicast Observables so that we can trigger the
login/logout even if the caller doesn't subscribe.

The second bug was that user$ and loggedIn$ both returned a value
before we got the response from me. This meant that we redirected to
the login page before we were able to check if we were already logged
in.