### PR TITLE
Continuing to build the Discord API

### DIFF
--- a/arisia-remote/app/arisia/discord/DiscordService.scala
+++ b/arisia-remote/app/arisia/discord/DiscordService.scala
@@ -75,7 +75,6 @@ class DiscordServiceImpl(
     loadMembers().map { members =>
       findMemberIn(creds, members) match {
         case Some(member) => {
-          // TODO:
           Right(member)
         }
         case _ => Left("Please join the Arisia Discord server first, then come back and try again!")

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -60,6 +60,8 @@ arisia {
       guildId = "743094117554454599"
       # The base-level role that is enabled for attendees
       arisianRoleId = "759881274269237271"
+      # How many records to load from Discord at a time
+      page.size = 100
     }
   }
 

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -51,6 +51,7 @@ arisia {
 
   discord {
     bot {
+      baseUrl = "https://discord.com/api"
       # Turn this on to begin processing bot events
       # THIS IS HIGHLY DANGEROUS, and you probably don't need it in your dev environment unless you are Gail or Justin.
       enabled = false


### PR DESCRIPTION
This now actually sets the user info in the DB when you log in, so that we can associate the Discord info with it.

This now loads the Arisia Discord server's member list properly, paginating the way the Discord API wants you to do.

We cache the member list, in the hope that we will sometimes be able to use the cached info instead of having to load the whole bloody thing.

We store the discord information in the user_info table for later access.

In theory, we set your Discord nickname to your badge name; that isn't working for me, but I suspect that's because I'm a Server Admin.