### PR TITLE
Assisted Discord setup API

### DIFF
--- a/arisia-remote/app/arisia/controllers/DiscordController.scala
+++ b/arisia-remote/app/arisia/controllers/DiscordController.scala
@@ -1,8 +1,8 @@
 package arisia.controllers
 
 import arisia.auth.LoginService
-import arisia.discord.{DiscordUserCredentials, DiscordService}
-import arisia.discord.DiscordUserCredentials
+import arisia.discord.{DiscordUserCredentials, DiscordService, DiscordHelpCredentials}
+import play.api.Configuration
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
@@ -12,11 +12,13 @@ import scala.concurrent.{Future, ExecutionContext}
 class DiscordController(
   val controllerComponents: ControllerComponents,
   val loginService: LoginService,
-  discordService: DiscordService
+  discordService: DiscordService,
+  config: Configuration
 )(
   implicit val ec: ExecutionContext
 ) extends BaseController
   with AdminControllerFuncs
+  with UserFuncs
   with I18nSupport
 {
   // TODO: remove this test entry point
@@ -45,6 +47,31 @@ class DiscordController(
         result.getOrElse(Future.successful(BadRequest(s"""{"success":"false", "message":"That isn't the right input!"}""")))
       }
       case _ => Future.successful(Forbidden("You need to be logged in to do this!"))
+    }
+  }
+
+  val sharedSecret = config.get[String]("arisia.discord.bot.shared.secret")
+
+  def generateAssistSecret(): EssentialAction = withLoggedInUser { userRequest =>
+    Future.successful(Ok(discordService.generateAssistSecret(userRequest.user)))
+  }
+
+  def assistedAddArisian(): EssentialAction = Action.async(controllerComponents.parsers.tolerantJson)  { implicit request =>
+    request.headers.get("X-Shared-Secret") match {
+      case Some(secret) if (secret == sharedSecret) => {
+        request.body.asOpt[DiscordHelpCredentials] match {
+          case Some(creds) => {
+            discordService.addArisianAssisted(creds).map {
+              _ match {
+                case Right(member) => Ok("")
+                case Left(error) => BadRequest(error)
+              }
+            }
+          }
+          case _ => Future.successful(BadRequest("Malformed request to help add an Arisian"))
+        }
+      }
+      case _ => Future.successful(Unauthorized("Shared secret not found in the X-Shared"))
     }
   }
 }

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -63,6 +63,8 @@ arisia {
       arisianRoleId = "759881274269237271"
       # How many records to load from Discord at a time
       page.size = 100
+      # The shared secret between the Lambda side of Arisiabot and this
+      shared.secret = "fakesecret"
     }
   }
 

--- a/arisia-remote/conf/evolutions/default/11.sql
+++ b/arisia-remote/conf/evolutions/default/11.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+ALTER TABLE user_info ADD COLUMN badge_name text DEFAULT '' NOT NULL;
+
+-- !Downs
+
+ALTER TABLE user_info DROP COLUMN badge_name;

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -64,6 +64,32 @@ DELETE  /api/settings/:key           arisia.controllers.SettingsController.dropS
 #      description: success
 ###
 POST    /api/discord/addArisian      arisia.controllers.DiscordController.addArisian()
+###
+#  summary: fetch a secret to allow this user to verify for help getting hooked up to Discord
+#  responses:
+#    200:
+#      description: success
+###
+GET     /api/discord/getAssistSecret arisia.controllers.DiscordController.generateAssistSecret()
+###
+#  summary: via Lambda, allow Help Desk to add somebody as an Arisian
+#  parameters:
+#    - in: header
+#      name: X-Shared-Secret
+#      schema:
+#        type: string
+#    - name: body
+#      schema:
+#        $ref: '#/definitions/arisia.discord.DiscordHelpCredentials'
+#  responses:
+#    200:
+#      description: success
+#    401:
+#      description: shared secret header not found
+#    400:
+#      description: passed-in info not valid
+###
+POST    /api/discord/assistAddArisian arisia.controllers.DiscordController.assistedAddArisian()
 
 # Admin UI, separate from the attendee-facing site
 GET     /admin                       arisia.controllers.AdminController.home()

--- a/arisia-remote/conf/secrets.conf.template
+++ b/arisia-remote/conf/secrets.conf.template
@@ -45,3 +45,5 @@ arisia.cm.test.user.badgeNumber = ""
 
 # The token used to authenticate the Discord bot:
 arisia.discord.bot.token = ""
+# The shared secret between Lambda and Backend:
+arisia.discord.bot.shared.secret = ""


### PR DESCRIPTION
This provides two new entry points:

* `GET /api/discord/getAssistSecret` returns a secret that a user can use in order to seek help getting set up with Discord.
* `POST /api/discord/assistAddArisian` allows Help Desk to provide assistance.

The latter entry point requires a `X-Shared-Secret` header, since it is intended solely for the use of Lambda. (Gail and Justin will agree on a secret for production, which goes into secrets.conf.)

It takes the following data structure:
```
{ "badgeNumber": "1111", "secret": "xxxx", "discordId": "30940493039303930" }
```
The secret comes from the other entry point, and validates the user. The Discord ID comes from the slash comment that Help Desk uses.

Includes an enhancement to store the Badge Name in the DB, which had previously been overlooked.

Fixes #275 