### PR TITLE
Fix /api/me to return Unauthorized if you're not logged in.

### DIFF
--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -25,8 +25,7 @@ class LoginController (
   def me(): EssentialAction = Action { implicit request =>
     request.session.get(userKey) match {
       case Some(jsonStr) => Ok(jsonStr)
-        // TODO: is there a more robust way to make sure that we hit all the fields here?
-      case None => Ok("""{"id":null,"name":null}""")
+      case None => Unauthorized("""{"id":null,"name":null}""")
     }
   }
 

--- a/frontend/src/app/_services/account.service.ts
+++ b/frontend/src/app/_services/account.service.ts
@@ -23,6 +23,10 @@ export class AccountService {
       user => {
         this.user = user;
         this.user$.next(this.user);
+      },
+      err => {
+        this.user = undefined;
+        this.user$.next(this.user);
       });
     this.loggedIn$ = this.user$.pipe(
       map(user => !!user),


### PR DESCRIPTION
The existing path was causing the frontend to fall back to defaults, resulting in a rash of people showing up as "Joe". This should make it easier to get that behavior right.