### PR TITLE
Add door times

### DIFF
--- a/arisia-remote/app/arisia/GeneralModule.scala
+++ b/arisia-remote/app/arisia/GeneralModule.scala
@@ -4,9 +4,9 @@ import akka.actor.ActorSystem
 import arisia.admin.{RoomServiceImpl, RoomService, AdminServiceImpl, AdminService}
 import arisia.auth.{CMService, CMServiceImpl, LoginService, LoginServiceImpl}
 import arisia.db.{DBServiceImpl, DBService}
-import arisia.discord.{DiscordService, DiscordServiceImpl}
+import arisia.discord.{DiscordServiceImpl, DiscordService}
 import arisia.fun.{DuckServiceImpl, DuckService}
-import arisia.general.{LifecycleServiceImpl, LifecycleService, SettingsService, SettingsServiceImpl}
+import arisia.general.{SettingsServiceImpl, FileService, LifecycleServiceImpl, SettingsService, LifecycleService, FileServiceImpl}
 import com.softwaremill.macwire.wire
 import arisia.schedule.{ScheduleService, ScheduleQueueService, ScheduleServiceImpl, StarService, StarServiceImpl, ScheduleQueueServiceImpl}
 import arisia.timer.{TimerService, TimeServiceImpl, TimerServiceImpl, TimeService, Ticker, TickerImpl}
@@ -30,6 +30,7 @@ trait GeneralModule extends ZoomModule {
   lazy val dbService: DBService = wire[DBServiceImpl]
   lazy val discordService: DiscordService = wire[DiscordServiceImpl]
   lazy val duckService: DuckService = wire[DuckServiceImpl]
+  lazy val fileService: FileService = wire[FileServiceImpl]
   lazy val lifecycleService: LifecycleService = wire[LifecycleServiceImpl]
   lazy val loginService: LoginService = wire[LoginServiceImpl]
   lazy val roomService: RoomService = wire[RoomServiceImpl]

--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -95,7 +95,7 @@ class AdminController (
     addFunc: (AdminService, LoginId) => Future[Int],
     onSuccess: Request[AnyContent] => Future[Result],
     onError: Call
-  ): AdminInfo => Future[Result] = { info =>
+  ): AdminInfo[AnyContent] => Future[Result] = { info =>
     implicit val request = info.request
 
     usernameForm.bindFromRequest().fold(
@@ -113,7 +113,7 @@ class AdminController (
     idStr: String,
     removeFunc: (AdminService, LoginId) => Future[Int],
     whenFinished: Call
-  ): AdminInfo => Future[Result] = { info =>
+  ): AdminInfo[AnyContent] => Future[Result] = { info =>
     val id = LoginId(idStr)
     val fut = for {
       targetPerms <- loginService.getPermissions(id)

--- a/arisia-remote/app/arisia/controllers/AdminControllerFuncs.scala
+++ b/arisia-remote/app/arisia/controllers/AdminControllerFuncs.scala
@@ -45,7 +45,8 @@ trait AdminControllerFuncs { self: BaseController =>
    */
   def adminsOnly[T](parser: BodyParser[T])(f: AdminInfo[T] => Result): EssentialAction =
     adminsOnlyAsync[T](parser)(info => Future.successful(f(info)))
-  def adminsOnly(f: AdminInfo[AnyContent] => Result): EssentialAction = adminsOnly(f)
+  def adminsOnly(f: AdminInfo[AnyContent] => Result): EssentialAction =
+    adminsOnly(controllerComponents.parsers.anyContent)(f)
 
   /**
    * Enhanced version of adminsOnlyAsync, for stuff that only super-admins can do.
@@ -58,10 +59,12 @@ trait AdminControllerFuncs { self: BaseController =>
         Future.successful(Forbidden("You need super-admin permission for this"))
       }
     }
-  def superAdminsOnlyAsync(f: AdminInfo[AnyContent] => Future[Result]): EssentialAction = superAdminsOnlyAsync(f)
+  def superAdminsOnlyAsync(f: AdminInfo[AnyContent] => Future[Result]): EssentialAction =
+    superAdminsOnlyAsync(controllerComponents.parsers.anyContent)(f)
 
   def superAdminsOnly[T](parser: BodyParser[T])(f: AdminInfo[T] => Result): EssentialAction =
     superAdminsOnlyAsync(parser)(info => Future.successful(f(info)))
-  def superAdminsOnly(f: AdminInfo[AnyContent] => Result): EssentialAction = superAdminsOnly(f)
+  def superAdminsOnly(f: AdminInfo[AnyContent] => Result): EssentialAction =
+    superAdminsOnly(controllerComponents.parsers.anyContent)(f)
 
 }

--- a/arisia-remote/app/arisia/controllers/ControllerModule.scala
+++ b/arisia-remote/app/arisia/controllers/ControllerModule.scala
@@ -22,6 +22,7 @@ trait ControllerModule extends GeneralModule with ZoomModule {
   lazy val adminController: AdminController = wire[AdminController]
   lazy val discordController: DiscordController = wire[DiscordController]
   lazy val duckController: DuckController = wire[DuckController]
+  lazy val fileController: FileController = wire[FileController]
   lazy val frontendController: FrontendController = wire[FrontendController]
   lazy val loginController: LoginController = wire[LoginController]
   lazy val scheduleController: ScheduleController = wire[ScheduleController]

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -39,7 +39,8 @@ class FileController(
   def multipartFormDataAsBytes: BodyParser[MultipartFormData[ByteString]] =
     controllerComponents.parsers.multipartFormData(byteStringFilePartHandler)
 
-  def uploadArtshowMetadata(): EssentialAction = Action(multipartFormDataAsBytes) { implicit request =>
+  def uploadArtshowMetadata(): EssentialAction = adminsOnly(multipartFormDataAsBytes) { adminInfo =>
+    val request = adminInfo.request
     // Rather than farting around with the terribly sophisticated and terribly hard-to-use multipart machinery
     // built into Play, we're doing this as dead-simply as we can:
     val fileParts: Seq[FilePart[ByteString]] = request.body.files

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -1,16 +1,18 @@
 package arisia.controllers
 
+import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import arisia.auth.LoginService
 
 import scala.concurrent.ExecutionContext
 import play.api.i18n.I18nSupport
-import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
+import play.api.mvc.{ControllerComponents, BodyParser, BaseController, EssentialAction, MultipartFormData}
 import play.api.data._
 import play.api.data.Forms._
 import play.api.libs.streams.Accumulator
+import play.api.mvc.MultipartFormData.FilePart
 import play.core.Paths
-import play.mvc.Http.MultipartFormData.{FileInfo, FilePart}
+import play.core.parsers.Multipart.{FilePartHandler, FileInfo}
 
 class FileController(
   val controllerComponents: ControllerComponents,
@@ -25,10 +27,22 @@ class FileController(
     Ok(arisia.views.html.uploadMetadata())
   }
 
-  def uploadArtshowMetadata(): EssentialAction = Action(controllerComponents.parsers.raw) { implicit request =>
+  def byteStringFilePartHandler: FilePartHandler[ByteString] = {
+    case FileInfo(partName, filename, contentType, dispositionType) =>
+      Accumulator(Sink.fold[ByteString, ByteString](ByteString()) { (accumulator, data) =>
+        accumulator ++ data
+      }.mapMaterializedValue(fbs => fbs.map(bs => {
+        FilePart(partName, filename, contentType, bs)
+      })))
+  }
+
+  def multipartFormDataAsBytes: BodyParser[MultipartFormData[ByteString]] =
+    controllerComponents.parsers.multipartFormData(byteStringFilePartHandler)
+
+  def uploadArtshowMetadata(): EssentialAction = Action(multipartFormDataAsBytes) { implicit request =>
     // Rather than farting around with the terribly sophisticated and terribly hard-to-use multipart machinery
     // built into Play, we're doing this as dead-simply as we can:
-    val body = request.body.asBytes().map(_.utf8String)
+    val body: String = request.body.files.head.ref.utf8String
     println(s"The body is:\n$body")
     Redirect(routes.AdminController.home())
   }

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -58,4 +58,16 @@ class FileController(
   def uploadArtshowMetadata(): EssentialAction = uploadBase(FileType.ArtshowMetadata)
   def uploadDealersMetadata(): EssentialAction = uploadBase(FileType.DealersMetadata)
 
+  def getMetadataBase(tpe: FileType): EssentialAction = Action.async { implicit request =>
+    fileService.getFile(tpe).map {
+      _ match {
+        case Some(metadata) => Ok(metadata)
+        case _ => NotFound("")
+      }
+    }
+  }
+
+  def getArtshowMetadata(): EssentialAction = getMetadataBase(FileType.ArtshowMetadata)
+  def getDealersMetadata(): EssentialAction = getMetadataBase(FileType.DealersMetadata)
+
 }

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -1,0 +1,48 @@
+package arisia.controllers
+
+import akka.util.ByteString
+import arisia.auth.LoginService
+
+import scala.concurrent.ExecutionContext
+import play.api.i18n.I18nSupport
+import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
+import play.api.data._
+import play.api.data.Forms._
+import play.api.libs.streams.Accumulator
+import play.core.Paths
+import play.mvc.Http.MultipartFormData.{FileInfo, FilePart}
+
+class FileController(
+  val controllerComponents: ControllerComponents,
+  val loginService: LoginService
+)(
+  implicit val ec: ExecutionContext
+) extends BaseController
+  with AdminControllerFuncs
+  with I18nSupport
+{
+  type FilePartHandler[A] = FileInfo => Accumulator[ByteString, FilePart[A]]
+
+  def handleFilePartAsFile: FilePartHandler[File] = ???
+//  {
+//    case FileInfo(partName, filename, contentType, dispositionType) =>
+//      val perms       = java.util.EnumSet.of(OWNER_READ, OWNER_WRITE)
+//      val attr        = PosixFilePermissions.asFileAttribute(perms)
+//      val path        = JFiles.createTempFile("multipartBody", "tempFile", attr)
+//      val file        = path.toFile
+//      val fileSink    = FileIO.toPath(path)
+//      val accumulator = Accumulator(fileSink)
+//      accumulator.map {
+//        case IOResult(count, status) =>
+//          FilePart(partName, filename, contentType, file, count, dispositionType)
+//      }(ec)
+//  }
+
+  def uploadCustom = Action(parse.multipartFormData(handleFilePartAsFile)) { request =>
+    val fileOption = request.body.file("name").map {
+      case FilePart(key, filename, contentType, file, fileSize, dispositionType) =>
+        file.toPath
+    }
+
+    Ok(s"File uploaded: $fileOption")
+  }}

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -41,7 +41,7 @@ class FileController(
   def multipartFormDataAsBytes: BodyParser[MultipartFormData[ByteString]] =
     controllerComponents.parsers.multipartFormData(byteStringFilePartHandler)
 
-  def uploadArtshowMetadata(): EssentialAction = adminsOnlyAsync(multipartFormDataAsBytes) { adminInfo =>
+  def uploadBase(tpe: FileType): EssentialAction = adminsOnlyAsync(multipartFormDataAsBytes) { adminInfo =>
     val request = adminInfo.request
     // Rather than farting around with the terribly sophisticated and terribly hard-to-use multipart machinery
     // built into Play, we're doing this as dead-simply as we can:
@@ -50,8 +50,12 @@ class FileController(
       current ++ next.ref
     }
     val body: String = fullByteString.utf8String
-    fileService.setFile(FileType.ArtshowMetadata, body).map { _ =>
+    fileService.setFile(tpe, body).map { _ =>
       Redirect(routes.AdminController.home())
     }
   }
+
+  def uploadArtshowMetadata(): EssentialAction = uploadBase(FileType.ArtshowMetadata)
+  def uploadDealersMetadata(): EssentialAction = uploadBase(FileType.DealersMetadata)
+
 }

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -42,7 +42,11 @@ class FileController(
   def uploadArtshowMetadata(): EssentialAction = Action(multipartFormDataAsBytes) { implicit request =>
     // Rather than farting around with the terribly sophisticated and terribly hard-to-use multipart machinery
     // built into Play, we're doing this as dead-simply as we can:
-    val body: String = request.body.files.head.ref.utf8String
+    val fileParts: Seq[FilePart[ByteString]] = request.body.files
+    val fullByteString: ByteString = fileParts.foldLeft(ByteString.empty) { (current, next) =>
+      current ++ next.ref
+    }
+    val body: String = fullByteString.utf8String
     println(s"The body is:\n$body")
     Redirect(routes.AdminController.home())
   }

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -19,30 +19,17 @@ class FileController(
   implicit val ec: ExecutionContext
 ) extends BaseController
   with AdminControllerFuncs
-  with I18nSupport
-{
-  type FilePartHandler[A] = FileInfo => Accumulator[ByteString, FilePart[A]]
+  with I18nSupport {
 
-  def handleFilePartAsFile: FilePartHandler[File] = ???
-//  {
-//    case FileInfo(partName, filename, contentType, dispositionType) =>
-//      val perms       = java.util.EnumSet.of(OWNER_READ, OWNER_WRITE)
-//      val attr        = PosixFilePermissions.asFileAttribute(perms)
-//      val path        = JFiles.createTempFile("multipartBody", "tempFile", attr)
-//      val file        = path.toFile
-//      val fileSink    = FileIO.toPath(path)
-//      val accumulator = Accumulator(fileSink)
-//      accumulator.map {
-//        case IOResult(count, status) =>
-//          FilePart(partName, filename, contentType, file, count, dispositionType)
-//      }(ec)
-//  }
+  def manageMetadata(): EssentialAction = Action { implicit request =>
+    Ok(arisia.views.html.uploadMetadata())
+  }
 
-  def uploadCustom = Action(parse.multipartFormData(handleFilePartAsFile)) { request =>
-    val fileOption = request.body.file("name").map {
-      case FilePart(key, filename, contentType, file, fileSize, dispositionType) =>
-        file.toPath
-    }
-
-    Ok(s"File uploaded: $fileOption")
-  }}
+  def uploadArtshowMetadata(): EssentialAction = Action(controllerComponents.parsers.raw) { implicit request =>
+    // Rather than farting around with the terribly sophisticated and terribly hard-to-use multipart machinery
+    // built into Play, we're doing this as dead-simply as we can:
+    val body = request.body.asBytes().map(_.utf8String)
+    println(s"The body is:\n$body")
+    Redirect(routes.AdminController.home())
+  }
+}

--- a/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
@@ -86,7 +86,7 @@ class ScheduleTestController(
           List(ProgramItemLoc(input.loc)),
           people,
           toField(input.desc, ProgramItemDesc(_)),
-          None, None, None, None
+          None, None, None, None, None, None
         )
 
         scheduleService.addTestItem(item)

--- a/arisia-remote/app/arisia/general/FileService.scala
+++ b/arisia-remote/app/arisia/general/FileService.scala
@@ -9,6 +9,8 @@ import scala.concurrent.{Future, ExecutionContext}
 
 trait FileService {
   def setFile(tpe: FileType, content: String): Future[Int]
+
+  def getFile(tpe: FileType): Future[Option[String]]
 }
 
 class FileServiceImpl(
@@ -27,6 +29,17 @@ class FileServiceImpl(
            DO UPDATE SET value = $content"""
         .update
         .run
+    )
+  }
+
+  def getFile(tpe: FileType): Future[Option[String]] = {
+    dbService.run(
+      sql"""
+           SELECT value
+             FROM text_files
+            WHERE name = ${tpe.value}"""
+        .query[String]
+        .option
     )
   }
 }

--- a/arisia-remote/app/arisia/general/FileService.scala
+++ b/arisia-remote/app/arisia/general/FileService.scala
@@ -3,8 +3,9 @@ package arisia.general
 import arisia.db.DBService
 import play.api.Logging
 
-trait FileService {
 
+
+trait FileService {
 }
 
 class FileServiceImpl(

--- a/arisia-remote/app/arisia/general/FileService.scala
+++ b/arisia-remote/app/arisia/general/FileService.scala
@@ -1,0 +1,14 @@
+package arisia.general
+
+import arisia.db.DBService
+import play.api.Logging
+
+trait FileService {
+
+}
+
+class FileServiceImpl(
+  dbService: DBService
+) extends FileService with Logging {
+
+}

--- a/arisia-remote/app/arisia/general/FileService.scala
+++ b/arisia-remote/app/arisia/general/FileService.scala
@@ -2,14 +2,31 @@ package arisia.general
 
 import arisia.db.DBService
 import play.api.Logging
+import doobie._
+import doobie.implicits._
 
-
+import scala.concurrent.{Future, ExecutionContext}
 
 trait FileService {
+  def setFile(tpe: FileType, content: String): Future[Int]
 }
 
 class FileServiceImpl(
   dbService: DBService
+)(
+  implicit ec: ExecutionContext
 ) extends FileService with Logging {
-
+  def setFile(tpe: FileType, content: String): Future[Int] = {
+    dbService.run(
+      sql"""
+           INSERT INTO text_files
+           (name, value)
+           VALUES
+           (${tpe.value}, $content)
+           ON CONFLICT (name)
+           DO UPDATE SET value = $content"""
+        .update
+        .run
+    )
+  }
 }

--- a/arisia-remote/app/arisia/general/FileType.scala
+++ b/arisia-remote/app/arisia/general/FileType.scala
@@ -1,0 +1,12 @@
+package arisia.general
+
+import enumeratum.values._
+
+sealed abstract class FileType(val value: String) extends StringEnumEntry
+
+object FileType extends StringPlayEnum[FileType] {
+  case object ArtshowMetadata extends FileType("artshow")
+  case object DealersMetadata extends FileType("dealers")
+
+  val values = findValues
+}

--- a/arisia-remote/app/arisia/models/ProgramItem.scala
+++ b/arisia-remote/app/arisia/models/ProgramItem.scala
@@ -2,6 +2,7 @@ package arisia.models
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDate, LocalTime}
+import scala.jdk.DurationConverters._
 
 import arisia.util._
 import play.api.libs.json._
@@ -91,7 +92,9 @@ case class ProgramItem(
   timestamp: Option[ProgramItemTimestamp],
   prepFor: Option[ProgramItemId],
   zoomStart: Option[ProgramItemTimestamp],
-  zoomEnd: Option[ProgramItemTimestamp]
+  zoomEnd: Option[ProgramItemTimestamp],
+  doorsOpen: Option[ProgramItemTimestamp],
+  doorsClose: Option[ProgramItemTimestamp]
 ) {
   lazy val when: Instant = {
     timestamp.map(_.t).getOrElse(Instant.MIN)
@@ -99,6 +102,7 @@ case class ProgramItem(
   lazy val duration: FiniteDuration = {
     mins.map(_.toInt.minutes).getOrElse(0.minutes)
   }
+  lazy val end: Instant = when.plus(duration.toJava)
 }
 object ProgramItem {
   implicit val fmt: Format[ProgramItem] = (
@@ -117,6 +121,8 @@ object ProgramItem {
       (JsPath \ "prepFor").formatNullable[ProgramItemId] and
       // The times that the Zoom meetings starts/stops -- only set for prep sessions
       (JsPath \ "zoomStart").formatNullable[ProgramItemTimestamp] and
-      (JsPath \ "zoomEnd").formatNullable[ProgramItemTimestamp]
+      (JsPath \ "zoomEnd").formatNullable[ProgramItemTimestamp] and
+      (JsPath \ "doorsOpen").formatNullable[ProgramItemTimestamp] and
+      (JsPath \ "doorsClose").formatNullable[ProgramItemTimestamp]
     )(ProgramItem.apply, unlift(ProgramItem.unapply))
 }

--- a/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
@@ -207,7 +207,7 @@ class ScheduleQueueServiceImpl(
       _ <- dbService.run(
         sql"""
               DELETE FROM active_program_items
-               WHERE program_item_id = '${item.itemId.v}'
+               WHERE program_item_id = ${item.itemId.v}
              """
           .update
           .run

--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -12,4 +12,5 @@
   <h2><a href="/admin/manageTech">Manage Tech</a></h2>
   <h2><a href="/admin/ducks">Manage Ducks</a></h2>
   <h2><a href="/test/scheduleItem">Add Test Schedule Item</a></h2>
+  <h2><a href="/admin/manageMetadata">Manage Metadata</a></h2>
 }

--- a/arisia-remote/app/arisia/views/uploadMetadata.scala.html
+++ b/arisia-remote/app/arisia/views/uploadMetadata.scala.html
@@ -1,0 +1,19 @@
+@(
+)(
+implicit request: RequestHeader, messagesProvider: MessagesProvider
+)
+
+@main("Manage Metadata") {
+  <h1>Manage Metadata</h1>
+
+  <p>This page allows you to upload the metadata files for various purposes. <b>Use this with care!</b>
+  We don't do any sort of validation that the uploaded file matches the desired format, so you can
+  seriously mess things up here if you aren't careful.</p>
+
+  @helper.form(action = arisia.controllers.routes.FileController.uploadArtshowMetadata, Symbol("enctype") -> "multipart/form-data") {
+    <input type="file" name="artshow">
+    <p>
+      <input type="submit">
+    </p>
+  }
+}

--- a/arisia-remote/app/arisia/views/uploadMetadata.scala.html
+++ b/arisia-remote/app/arisia/views/uploadMetadata.scala.html
@@ -10,8 +10,21 @@ implicit request: RequestHeader, messagesProvider: MessagesProvider
   We don't do any sort of validation that the uploaded file matches the desired format, so you can
   seriously mess things up here if you aren't careful.</p>
 
+  <p><b>Make sure you are uploading the right file to the right place!</b></p>
+
+  <h2>Art Show Metadata</h2>
+
   @helper.form(action = arisia.controllers.routes.FileController.uploadArtshowMetadata(), Symbol("enctype") -> "multipart/form-data") {
     <input type="file" name="artshow">
+    <p>
+      <input type="submit">
+    </p>
+  }
+
+  <h2>Dealers Metadata</h2>
+
+  @helper.form(action = arisia.controllers.routes.FileController.uploadDealersMetadata(), Symbol("enctype") -> "multipart/form-data") {
+    <input type="file" name="dealers">
     <p>
       <input type="submit">
     </p>

--- a/arisia-remote/app/arisia/views/uploadMetadata.scala.html
+++ b/arisia-remote/app/arisia/views/uploadMetadata.scala.html
@@ -10,7 +10,7 @@ implicit request: RequestHeader, messagesProvider: MessagesProvider
   We don't do any sort of validation that the uploaded file matches the desired format, so you can
   seriously mess things up here if you aren't careful.</p>
 
-  @helper.form(action = arisia.controllers.routes.FileController.uploadArtshowMetadata, Symbol("enctype") -> "multipart/form-data") {
+  @helper.form(action = arisia.controllers.routes.FileController.uploadArtshowMetadata(), Symbol("enctype") -> "multipart/form-data") {
     <input type="file" name="artshow">
     <p>
       <input type="submit">

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -112,6 +112,10 @@ POST    /admin/editRoom              arisia.controllers.ZoomController.roomModif
 # This is mainly internal, for testing; we might add a UI if we find a use for it, but don't do that casually:
 POST    /admin/meeting               arisia.controllers.AdminController.startMeeting()
 DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeting(meetingId)
+
+GET     /admin/manageMetadata        arisia.controllers.FileController.manageMetadata()
+POST    /admin/uploadArtshowMetadata arisia.controllers.FileController.uploadArtshowMetadata()
+
 # Note the non-standard path, which is configured in application.conf, so that frontend
 # can own /assets
 GET     /admin/assets/*file          controllers.Assets.versioned(path="/public", file: Asset)

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -115,6 +115,7 @@ DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeti
 
 GET     /admin/manageMetadata        arisia.controllers.FileController.manageMetadata()
 POST    /admin/uploadArtshowMetadata arisia.controllers.FileController.uploadArtshowMetadata()
+POST    /admin/uploadDealersMetadata arisia.controllers.FileController.uploadDealersMetadata()
 
 # Note the non-standard path, which is configured in application.conf, so that frontend
 # can own /assets

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -54,6 +54,30 @@ POST    /api/settings                arisia.controllers.SettingsController.addSe
 DELETE  /api/settings/:key           arisia.controllers.SettingsController.dropSetting(key)
 
 ###
+#  summary: fetch the metadata for the Art Show
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/metadata/artshow        arisia.controllers.FileController.getArtshowMetadata()
+
+###
+#  summary: fetch the metadata for the Dealers
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/metadata/dealers        arisia.controllers.FileController.getDealersMetadata()
+
+###
 #  summary: make this person an Arisian
 #  parameters:
 #    - name: body


### PR DESCRIPTION
This adds two new fields to program items with Zoom.  `doorsOpen` is the timestamp to start showing the entry links; `doorsClose` is when to stop.  (Note that doorsOpen is intentionally five minutes before the actual panel start time.)

The intent is to make it easier for the front end to show the links at the right times -- hopefully it's helpful.

For some reason, this PR is stupidly over-large: we seem to be having rebase problems.  Sorry about that.

Fixes #255 