### PR TITLE
Deal with case sensitivity in usernames

### DIFF
--- a/arisia-remote/app/arisia/admin/AdminService.scala
+++ b/arisia-remote/app/arisia/admin/AdminService.scala
@@ -65,7 +65,7 @@ class AdminServiceImpl(
       val query =
         fr"""INSERT INTO permissions
            (username, """ ++ column ++ fr""")
-           VALUES (${id.v}, TRUE)
+           VALUES (${id.lower}, TRUE)
            ON CONFLICT (username)
            DO UPDATE SET""" ++ column ++ fr"= TRUE"
       dbService.run(
@@ -80,7 +80,7 @@ class AdminServiceImpl(
       val query =
         fr"""UPDATE permissions
            SET""" ++ column ++ fr"""= FALSE
-           WHERE username = ${id.v}"""
+           WHERE username = ${id.lower}"""
       dbService.run(
         query
           .update

--- a/arisia-remote/app/arisia/auth/CMService.scala
+++ b/arisia-remote/app/arisia/auth/CMService.scala
@@ -111,7 +111,7 @@ class CMServiceImpl(
             }
           }
 
-          Right((LoginId(username), LoginName(badgeName)))
+          Right((LoginId(username.toLowerCase), LoginName(badgeName)))
         } else {
           logger.error(s"Got unexpected response from Convention Master when checking $username!")
           Left{LoginError.NoLogin}

--- a/arisia-remote/app/arisia/auth/LoginService.scala
+++ b/arisia-remote/app/arisia/auth/LoginService.scala
@@ -108,7 +108,7 @@ class LoginServiceImpl(
             INSERT INTO user_info
             (username, badge_number, badge_name, membership_type)
             VALUES
-            (${user.id.v}, ${user.badgeNumber.v}, ${user.name.v}, ${user.membershipType.value})
+            (${user.id.lower}, ${user.badgeNumber.v}, ${user.name.v}, ${user.membershipType.value})
             ON CONFLICT DO NOTHING
            """
         .update
@@ -146,7 +146,7 @@ class LoginServiceImpl(
                SET discord_username = ${discordMember.user.username},
                    discord_discriminator = ${discordMember.user.discriminator},
                    discord_id = ${discordMember.user.id}
-             WHERE username = ${who.id.v}
+             WHERE username = ${who.id.lower}
         """
         .update
         .run
@@ -156,7 +156,7 @@ class LoginServiceImpl(
   def fetchPermissionsQuery(id: LoginId): ConnectionIO[Option[Permissions]] =
     sql"""SELECT super_admin, admin, early_access, tech
          |FROM permissions
-         |WHERE username = ${id.v}""".stripMargin
+         |WHERE username = ${id.lower}""".stripMargin
     .query[Permissions]
     .option
 

--- a/arisia-remote/app/arisia/fun/DuckService.scala
+++ b/arisia-remote/app/arisia/fun/DuckService.scala
@@ -93,7 +93,7 @@ class DuckServiceImpl(
            INSERT INTO member_ducks
            (username, duck_id)
            VALUES
-           (${who.v}, $duckId)"""
+           (${who.lower}, $duckId)"""
               .update
               .run
           )
@@ -115,7 +115,7 @@ class DuckServiceImpl(
     dbService.run(
       sql"""
            DELETE FROM member_ducks
-            WHERE username = ${who.v} AND duck_id = $duck"""
+            WHERE username = ${who.lower} AND duck_id = $duck"""
         .update
         .run
     )

--- a/arisia-remote/app/arisia/general/SettingsService.scala
+++ b/arisia-remote/app/arisia/general/SettingsService.scala
@@ -23,7 +23,7 @@ class SettingsServiceImpl(
       sql"""
            SELECT k, v
              FROM user_settings
-            WHERE username = ${who.id.v}"""
+            WHERE username = ${who.id.lower}"""
         .query[(String, String)]
         .to[List]
         .map(_.toMap)
@@ -40,7 +40,7 @@ class SettingsServiceImpl(
             INSERT INTO user_settings
             (username, k, v)
             VALUES
-            (${who.id.v}, $k, $v)
+            (${who.id.lower}, $k, $v)
             ON CONFLICT (username, k)
             DO UPDATE SET v = $v
            """
@@ -55,7 +55,7 @@ class SettingsServiceImpl(
     dbService.run(
       sql"""
            DELETE FROM user_settings
-            WHERE username = ${who.id.v} and k = $which"""
+            WHERE username = ${who.id.lower} and k = $which"""
         .update
         .run
     )

--- a/arisia-remote/app/arisia/models/LoginUser.scala
+++ b/arisia-remote/app/arisia/models/LoginUser.scala
@@ -4,7 +4,9 @@ import arisia.auth.MembershipType
 import arisia.util.{StdString, StdStringUtils}
 import play.api.libs.json.{Format, Json, Writes}
 
-case class LoginId(v: String) extends StdString
+case class LoginId(v: String) extends StdString {
+  lazy val lower: String = v.toLowerCase
+}
 object LoginId extends StdStringUtils(new LoginId(_))
 
 case class LoginName(v: String) extends StdString

--- a/arisia-remote/app/arisia/schedule/StarService.scala
+++ b/arisia-remote/app/arisia/schedule/StarService.scala
@@ -25,7 +25,7 @@ class StarServiceImpl(
     val query =
       sql"""INSERT INTO starred_items
            (login_id, item_id)
-           VALUES (${who.v}, ${which.v})"""
+           VALUES (${who.lower}, ${which.v})"""
     dbService.run(
       query.
         update.
@@ -36,7 +36,7 @@ class StarServiceImpl(
   def removeStar(who: LoginId, which: ProgramItemId): Future[Int] = {
     val query =
       sql"""DELETE FROM starred_items
-           WHERE login_id = ${who.v} AND item_id = ${which.v}"""
+           WHERE login_id = ${who.lower} AND item_id = ${which.v}"""
     dbService.run(
       query.
         update.
@@ -48,7 +48,7 @@ class StarServiceImpl(
     val query =
       sql"""SELECT item_id
            FROM starred_items
-           WHERE login_id = ${who.v}"""
+           WHERE login_id = ${who.lower}"""
     dbService.run(
       query.
         query[ProgramItemId]


### PR DESCRIPTION
CM is case-insensitive. We aren't. That's a problem, and has caused a few snags. This tweaks the database code accordingly, by lowercasing the username across the board.

(It's a tad more ad-hoc than I'd like, but at this point it's probably the least-risk approach.)

Fixes #220 