### PR TITLE
Profile Support

### DIFF
--- a/arisia-remote/app/arisia/controllers/LoginController.scala
+++ b/arisia-remote/app/arisia/controllers/LoginController.scala
@@ -1,22 +1,36 @@
 package arisia.controllers
 
 import arisia.auth.{LoginError, LoginService}
-import arisia.models.{LoginRequest, LoginUser, LoginId}
+import arisia.fun.DuckService
+import arisia.models.{LoginRequest, LoginUser, LoginId, BadgeNumber, LoginName}
 import play.api.Configuration
 import play.api.http._
-import play.api.libs.json.{Json, JsValue}
+import play.api.libs.json.{Json, JsValue, Format}
 import play.api.mvc._
 
 import scala.concurrent.{Future, ExecutionContext}
 
+case class ProfileInfo(
+  id: LoginId,
+  name: LoginName,
+  badgeNumber: BadgeNumber,
+  zoomHost: Boolean,
+  ducks: List[String]
+)
+object ProfileInfo {
+  implicit val fmt: Format[ProfileInfo] = Json.format
+}
+
 class LoginController (
   val controllerComponents: ControllerComponents,
   config: Configuration,
-  loginService: LoginService
+  loginService: LoginService,
+  duckService: DuckService
 )(
   implicit ec: ExecutionContext
 )
   extends BaseController
+  with UserFuncs
 {
   import LoginController._
 
@@ -26,6 +40,27 @@ class LoginController (
     request.session.get(userKey) match {
       case Some(jsonStr) => Ok(jsonStr)
       case None => Unauthorized("""{"id":null,"name":null}""")
+    }
+  }
+
+  def getProfileInfo(badgeNum: String): EssentialAction = withLoggedInUser { userRequest =>
+    loginService.fetchUserInfo(BadgeNumber(badgeNum)).flatMap {
+      _ match {
+        case Some(user) => {
+          duckService.getDucksFor(user.id).map { ducks =>
+            val info = ProfileInfo(
+              user.id,
+              user.name,
+              user.badgeNumber,
+              user.zoomHost,
+              ducks.map(_.toString)
+            )
+            Ok(Json.toJson(info).toString)
+          }
+        }
+        case _ =>
+          Future.successful(NotFound(s"""{"success":"false", "message":"$badgeNum has not logged in to Virtual Arisia"}"""))
+      }
     }
   }
 

--- a/arisia-remote/app/arisia/fun/DuckService.scala
+++ b/arisia-remote/app/arisia/fun/DuckService.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import arisia.db.DBService
 import arisia.general.{LifecycleService, LifecycleItem}
-import arisia.models.LoginId
+import arisia.models.{LoginId, BadgeNumber}
 import arisia.util.Done
 import play.api.Logging
 import doobie._
@@ -36,6 +36,7 @@ object Duck {
 trait DuckService {
   // API endpoints
   def getDucks(): List[Duck]
+  def getDucksFor(who: LoginId): Future[List[Int]]
   def getDuck(id: Int): Option[Duck]
   def assignDuck(who: LoginId, duck: Int, from: String): Future[Int]
   def dropDuck(who: LoginId, duck: Int): Future[Int]
@@ -118,6 +119,17 @@ class DuckServiceImpl(
             WHERE username = ${who.lower} AND duck_id = $duck"""
         .update
         .run
+    )
+  }
+  def getDucksFor(who: LoginId): Future[List[Int]] = {
+    dbService.run(
+      sql"""
+            SELECT duck_id
+              FROM member_ducks
+             WHERE username = ${who.lower}
+           """
+        .query[Int]
+        .to[List]
     )
   }
 

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -21,6 +21,18 @@ POST    /api/login                   arisia.controllers.LoginController.login()
 
 GET     /api/me                      arisia.controllers.LoginController.me()
 
+###
+#  summary: fetch the Profile info for the specified person
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/user/:id                arisia.controllers.LoginController.getProfileInfo(id)
+
 # Logs the current user out
 # No body is expected on this one
 # Always succeeds with OK (200), regardless of whether the user was logged in or not

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -29,9 +29,21 @@ GET     /api/me                      arisia.controllers.LoginController.me()
 #      content:
 #        text/plain:
 #          schema:
-#            type: string
+#            $ref: '#/definitions/arisia.controllers.ProfileInfo'
 ###
 GET     /api/user/:id                arisia.controllers.LoginController.getProfileInfo(id)
+
+###
+#  summary: fetch the Profile info for the specified person
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            $ref: '#/definitions/arisia.controllers.ProfileInfo'
+###
+GET     /api/user                    arisia.controllers.LoginController.getProfileInfoForMe()
 
 # Logs the current user out
 # No body is expected on this one

--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val backend = (project in file("arisia-remote"))
       scalatestPlusPlay,
       swaggerUI
     ),
-    swaggerDomainNameSpaces := Seq("arisia.models", "arisia.discord"),
+    swaggerDomainNameSpaces := Seq("arisia.models", "arisia.discord", "arisia.controllers"),
     swaggerPrettyJson := true
   )
   .enablePlugins(PlayScala, SwaggerPlugin)


### PR DESCRIPTION
This adds two new entry points:
```
GET /api/user
GET /api/user/:id
```
The first one fetches your own profile info, the second someone else's.  Both are only available to logged-in users.

Fixes #306 -- the returned data structure should match the spec in there.  Note that some of that isn't properly tested yet (in particular, the duck list): yell if you find problems.