### PR TITLE
Provide config for the frontend

### DIFF
--- a/arisia-remote/app/arisia/controllers/FrontendController.scala
+++ b/arisia-remote/app/arisia/controllers/FrontendController.scala
@@ -5,7 +5,7 @@ import play.api.Configuration
 import play.api.http._
 import play.api.mvc._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class FrontendController(
   val controllerComponents: ControllerComponents,
@@ -16,16 +16,17 @@ class FrontendController(
   implicit ec: ExecutionContext
 )
   extends BaseController
+  with UserFuncs
 {
   def index(): Action[AnyContent] = assets.at("/frontend/index.html")
 
   def assetOrDefault(resource: String): Action[AnyContent] =
     if (resource.contains(".")) assets.versioned(s"/frontend/$resource") else index()
 
-  def getConfigEntry(name: String): EssentialAction = Action { implicit request =>
+  def getConfigEntry(name: String): EssentialAction = withLoggedInUser { userRequest =>
     config.getOptional[String](s"arisia.frontend.$name") match {
-      case Some(v) => Ok(v)
-      case _ => NotFound("")
+      case Some(v) => Future.successful(Ok(v))
+      case _ => Future.successful(NotFound(""))
     }
   }
 }

--- a/arisia-remote/app/arisia/controllers/FrontendController.scala
+++ b/arisia-remote/app/arisia/controllers/FrontendController.scala
@@ -21,4 +21,11 @@ class FrontendController(
 
   def assetOrDefault(resource: String): Action[AnyContent] =
     if (resource.contains(".")) assets.versioned(s"/frontend/$resource") else index()
+
+  def getConfigEntry(name: String): EssentialAction = Action { implicit request =>
+    config.getOptional[String](s"arisia.frontend.$name") match {
+      case Some(v) => Ok(v)
+      case _ => NotFound("")
+    }
+  }
 }

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -68,6 +68,12 @@ arisia {
     }
   }
 
+  frontend {
+    # This section is entirely for quasi-secrets desired by the frontend. The backend code does not refer to any
+    # of them explicitly; the frontend team should feel free to add entries here as desired. They will all be
+    # loaded and sent as String.
+  }
+
   schedule {
     # Once a minute, check whether we need to start/stop Zoom sessions:
     check.interval = 1m

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -21,6 +21,25 @@ POST    /api/login                   arisia.controllers.LoginController.login()
 
 GET     /api/me                      arisia.controllers.LoginController.me()
 
+
+###
+#  summary: fetch the specified frontend config entry
+#  parameters:
+#    - in: path
+#      name: name
+#      schema:
+#        type: string
+#      required: true
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/config/:name            arisia.controllers.FrontendController.getConfigEntry(name)
+
 ###
 #  summary: fetch the Profile info for the specified person
 #  responses:


### PR DESCRIPTION
This provides a new entry point:
```
GET /api/config/:name
```
Assuming that that value is in the backend config, it will return 200 with the value as the body. If the name is not known in the backend config, it will return 404.

In the backend config, the subtree `arisia.frontend` has been set aside for this purpose -- the frontend team are encouraged to put their values in there. The real values should go into secrets.conf; I recommend documenting those entries in secrets.conf.template and maybe application.conf, but that is not required.

So if, say, there is a backend config entry named `arisia.frontend.thingy`, you can call `GET /api/config/thingy` to fetch it.

Fixes #328 