### PR TITLE
Add upload and get entry points for Gaming and Events metadata

### DIFF
--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -57,6 +57,8 @@ class FileController(
 
   def uploadArtshowMetadata(): EssentialAction = uploadBase(FileType.ArtshowMetadata)
   def uploadDealersMetadata(): EssentialAction = uploadBase(FileType.DealersMetadata)
+  def uploadGamingMetadata(): EssentialAction = uploadBase(FileType.GamingMetadata)
+  def uploadEventsMetadata(): EssentialAction = uploadBase(FileType.EventsMetadata)
 
   def getMetadataBase(tpe: FileType): EssentialAction = Action.async { implicit request =>
     fileService.getFile(tpe).map {
@@ -69,5 +71,7 @@ class FileController(
 
   def getArtshowMetadata(): EssentialAction = getMetadataBase(FileType.ArtshowMetadata)
   def getDealersMetadata(): EssentialAction = getMetadataBase(FileType.DealersMetadata)
+  def getGamingMetadata(): EssentialAction = getMetadataBase(FileType.GamingMetadata)
+  def getEventsMetadata(): EssentialAction = getMetadataBase(FileType.EventsMetadata)
 
 }

--- a/arisia-remote/app/arisia/general/FileType.scala
+++ b/arisia-remote/app/arisia/general/FileType.scala
@@ -7,6 +7,8 @@ sealed abstract class FileType(val value: String) extends StringEnumEntry
 object FileType extends StringPlayEnum[FileType] {
   case object ArtshowMetadata extends FileType("artshow")
   case object DealersMetadata extends FileType("dealers")
+  case object GamingMetadata extends FileType("gaming")
+  case object EventsMetadata extends FileType("events")
 
   val values = findValues
 }

--- a/arisia-remote/app/arisia/views/uploadMetadata.scala.html
+++ b/arisia-remote/app/arisia/views/uploadMetadata.scala.html
@@ -29,4 +29,22 @@ implicit request: RequestHeader, messagesProvider: MessagesProvider
       <input type="submit">
     </p>
   }
+
+  <h2>Gaming Metadata</h2>
+
+  @helper.form(action = arisia.controllers.routes.FileController.uploadGamingMetadata(), Symbol("enctype") -> "multipart/form-data") {
+    <input type="file" name="gaming">
+    <p>
+      <input type="submit">
+    </p>
+  }
+
+  <h2>Events Metadata</h2>
+
+  @helper.form(action = arisia.controllers.routes.FileController.uploadEventsMetadata(), Symbol("enctype") -> "multipart/form-data") {
+    <input type="file" name="events">
+    <p>
+      <input type="submit">
+    </p>
+  }
 }

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -102,6 +102,31 @@ GET     /api/metadata/artshow        arisia.controllers.FileController.getArtsho
 ###
 GET     /api/metadata/dealers        arisia.controllers.FileController.getDealersMetadata()
 
+
+###
+#  summary: fetch the metadata for Gaming
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/metadata/gaming        arisia.controllers.FileController.getGamingMetadata()
+
+###
+#  summary: fetch the metadata for Events
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/metadata/events        arisia.controllers.FileController.getEventsMetadata()
+
 ###
 #  summary: make this person an Arisian
 #  parameters:
@@ -166,6 +191,8 @@ DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeti
 GET     /admin/manageMetadata        arisia.controllers.FileController.manageMetadata()
 POST    /admin/uploadArtshowMetadata arisia.controllers.FileController.uploadArtshowMetadata()
 POST    /admin/uploadDealersMetadata arisia.controllers.FileController.uploadDealersMetadata()
+POST    /admin/uploadGamingMetadata  arisia.controllers.FileController.uploadGamingMetadata()
+POST    /admin/uploadEventsMetadata  arisia.controllers.FileController.uploadEventsMetadata()
 
 # Note the non-standard path, which is configured in application.conf, so that frontend
 # can own /assets


### PR DESCRIPTION
This adds:
```
GET /api/metadata/gaming
GET /api/metadata/events
```
as well as the associated upload UI in Admin.

Fixes #314 