### PR TITLE
Add a simplistic Admin Audit Trail

### DIFF
--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -31,7 +31,7 @@ class AdminController (
   with Logging
 {
 
-  def home(): EssentialAction = adminsOnly { info =>
+  def home(): EssentialAction = adminsOnly("Loaded Home") { info =>
     Ok(arisia.views.html.adminHome(info.permissions))
   }
 
@@ -50,7 +50,7 @@ class AdminController (
   /**
    * For now, this is internal-only, for testing, and can only be accessed from Swagger.
    */
-  def startMeeting(): EssentialAction = adminsOnlyAsync { info =>
+  def startMeeting(): EssentialAction = adminsOnlyAsync("Started test meeting") { info =>
     val userId = config.get[String]("arisia.zoom.api.userId")
     zoomService.startMeeting("Ad hoc meeting", userId).map { errorOrMeeting =>
       errorOrMeeting match {
@@ -60,7 +60,7 @@ class AdminController (
     }
   }
 
-  def endMeeting(meetingIdStr: String): EssentialAction = adminsOnlyAsync { info =>
+  def endMeeting(meetingIdStr: String): EssentialAction = adminsOnlyAsync("Ended meeting manually") { info =>
     meetingIdStr.toLongOption match {
       case Some(meetingId) => {
         zoomService.endMeeting(meetingId).map { _ =>
@@ -104,6 +104,7 @@ class AdminController (
         Future.successful(Redirect(onError))
       },
       loginName => {
+        info.audit(s"Add Permission to ${loginName.v}")
         addFunc(adminService, loginName).flatMap(_ => onSuccess(request))
       }
     )
@@ -115,6 +116,7 @@ class AdminController (
     whenFinished: Call
   ): AdminInfo[AnyContent] => Future[Result] = { info =>
     val id = LoginId(idStr)
+    info.audit(s"Remove Permission from ${id.v}")
     val fut = for {
       targetPerms <- loginService.getPermissions(id)
       // Safety check: you can't remove privs from the super-admins:
@@ -139,12 +141,12 @@ class AdminController (
     )
   }
 
-  def manageAdmins(): EssentialAction = superAdminsOnlyAsync { info =>
+  def manageAdmins(): EssentialAction = superAdminsOnlyAsync("Managed Admins") { info =>
     implicit val request = info.request
     showManageAdmins()
   }
 
-  def addAdmin(): EssentialAction = superAdminsOnlyAsync {
+  def addAdmin(): EssentialAction = superAdminsOnlyAsync("Add Admin") {
     addPermission(
       _.addAdmin(_),
       showManageAdmins()(_),
@@ -152,7 +154,7 @@ class AdminController (
     )
   }
 
-  def removeAdmin(idStr: String): EssentialAction = superAdminsOnlyAsync {
+  def removeAdmin(idStr: String): EssentialAction = superAdminsOnlyAsync("Remove Admin") {
     removePermission(idStr, _.removeAdmin(_), routes.AdminController.manageAdmins())
   }
 
@@ -168,12 +170,12 @@ class AdminController (
       arisia.views.html.manageEarlyAccess(_, usernameForm.fill(LoginId("")))
     )
 
-  def manageEarlyAccess(): EssentialAction = adminsOnlyAsync { info =>
+  def manageEarlyAccess(): EssentialAction = adminsOnlyAsync("Manage Early Access") { info =>
     implicit val request = info.request
     showManageEarlyAccess()
   }
 
-  def addEarlyAccess(): EssentialAction = adminsOnlyAsync {
+  def addEarlyAccess(): EssentialAction = adminsOnlyAsync("Add Early Access") {
     addPermission(
       _.addEarlyAccess(_),
       showManageEarlyAccess()(_),
@@ -181,7 +183,7 @@ class AdminController (
     )
   }
 
-  def removeEarlyAccess(idStr: String): EssentialAction = adminsOnlyAsync {
+  def removeEarlyAccess(idStr: String): EssentialAction = adminsOnlyAsync("Remove Early Access") {
     removePermission(idStr, _.removeEarlyAccess(_), routes.AdminController.manageEarlyAccess())
   }
 
@@ -197,12 +199,12 @@ class AdminController (
       arisia.views.html.manageTech(_, usernameForm.fill(LoginId("")))
     )
 
-  def manageTech(): EssentialAction = adminsOnlyAsync { info =>
+  def manageTech(): EssentialAction = adminsOnlyAsync("Manage Tech") { info =>
     implicit val request = info.request
     showManageTech()
   }
 
-  def addTech(): EssentialAction = adminsOnlyAsync {
+  def addTech(): EssentialAction = adminsOnlyAsync("Add Tech") {
     addPermission(
       _.addTech(_),
       showManageTech()(_),
@@ -210,7 +212,7 @@ class AdminController (
     )
   }
 
-  def removeTech(idStr: String): EssentialAction = adminsOnlyAsync {
+  def removeTech(idStr: String): EssentialAction = adminsOnlyAsync("Remove Tech") {
     removePermission(idStr, _.removeTech(_), routes.AdminController.manageTech())
   }
 }

--- a/arisia-remote/app/arisia/controllers/AdminControllerFuncs.scala
+++ b/arisia-remote/app/arisia/controllers/AdminControllerFuncs.scala
@@ -1,7 +1,10 @@
 package arisia.controllers
 
+import java.util.concurrent.atomic.AtomicReference
+
 import arisia.auth.LoginService
 import arisia.models.{LoginUser, Permissions}
+import play.api.Logger
 import play.api.mvc._
 
 import scala.concurrent.{Future, ExecutionContext}
@@ -9,8 +12,18 @@ import scala.concurrent.{Future, ExecutionContext}
 trait AdminControllerFuncs { self: BaseController =>
   def loginService: LoginService
   implicit def ec: ExecutionContext
+  protected def logger: Logger
 
-  case class AdminInfo[T](request: Request[T], user: LoginUser, permissions: Permissions)
+  case class AdminInfo[T](request: Request[T], user: LoginUser, permissions: Permissions) {
+    val auditInfo: AtomicReference[List[String]] = new AtomicReference(List.empty)
+
+    def formatAudit(msg: String): String = s"Audit: ${user.id} - $msg"
+
+    def audit(msg: String): Unit = {
+      val fullMsg = formatAudit(msg)
+      auditInfo.accumulateAndGet(List(fullMsg), _ ++ _)
+    }
+  }
 
   /**
    * Standard wrapper -- the provided function will only be used iff the user is a logged-in Admin.
@@ -21,14 +34,19 @@ trait AdminControllerFuncs { self: BaseController =>
    *
    * @param f function that actually does something.
    */
-  def adminsOnlyAsync[T](parser: BodyParser[T])(f: AdminInfo[T] => Future[Result]): EssentialAction = Action(parser).async { implicit request =>
+  def adminsOnlyAsync[T](parser: BodyParser[T])(opName: String)(f: AdminInfo[T] => Future[Result]): EssentialAction = Action(parser).async { implicit request =>
     LoginController.loggedInUserBase[T]() match {
       case Some(user) => {
         loginService.getPermissions(user.id).flatMap { permissions =>
           if (permissions.admin) {
             // Okay, this is a person who is allowed to use the Admin UI
             val info = AdminInfo(request, user, permissions)
-            f(info)
+            f(info).map { result =>
+              info.audit(s"$opName completed: ${result.header.status}")
+              val fullAudit = info.auditInfo.get().reverse
+              fullAudit.foreach(msg => logger.info(msg))
+              result
+            }
           } else {
             Future.successful(Forbidden(s"You aren't allowed to use the Admin interface"))
           }
@@ -37,34 +55,34 @@ trait AdminControllerFuncs { self: BaseController =>
       case _ => Future.successful(NotFound("You aren't logged in!"))
     }
   }
-  def adminsOnlyAsync(f: AdminInfo[AnyContent] => Future[Result]): EssentialAction =
-    adminsOnlyAsync(controllerComponents.parsers.anyContent)(f)
+  def adminsOnlyAsync(opName: String)(f: AdminInfo[AnyContent] => Future[Result]): EssentialAction =
+    adminsOnlyAsync(controllerComponents.parsers.anyContent)(opName: String)(f)
 
   /**
    * Synchronous version of adminsOnlyAsync(), for simpler functions.
    */
-  def adminsOnly[T](parser: BodyParser[T])(f: AdminInfo[T] => Result): EssentialAction =
-    adminsOnlyAsync[T](parser)(info => Future.successful(f(info)))
-  def adminsOnly(f: AdminInfo[AnyContent] => Result): EssentialAction =
-    adminsOnly(controllerComponents.parsers.anyContent)(f)
+  def adminsOnly[T](parser: BodyParser[T])(opName: String)(f: AdminInfo[T] => Result): EssentialAction =
+    adminsOnlyAsync[T](parser)(opName: String)(info => Future.successful(f(info)))
+  def adminsOnly(opName: String)(f: AdminInfo[AnyContent] => Result): EssentialAction =
+    adminsOnly(controllerComponents.parsers.anyContent)(opName: String)(f)
 
   /**
    * Enhanced version of adminsOnlyAsync, for stuff that only super-admins can do.
    */
-  def superAdminsOnlyAsync[T](parser: BodyParser[T])(f: AdminInfo[T] => Future[Result]): EssentialAction =
-    adminsOnlyAsync[T](parser) { info =>
+  def superAdminsOnlyAsync[T](parser: BodyParser[T])(opName: String)(f: AdminInfo[T] => Future[Result]): EssentialAction =
+    adminsOnlyAsync[T](parser)(opName: String) { info =>
       if (info.permissions.superAdmin) {
         f(info)
       } else {
         Future.successful(Forbidden("You need super-admin permission for this"))
       }
     }
-  def superAdminsOnlyAsync(f: AdminInfo[AnyContent] => Future[Result]): EssentialAction =
-    superAdminsOnlyAsync(controllerComponents.parsers.anyContent)(f)
+  def superAdminsOnlyAsync(opName: String)(f: AdminInfo[AnyContent] => Future[Result]): EssentialAction =
+    superAdminsOnlyAsync(controllerComponents.parsers.anyContent)(opName: String)(f)
 
-  def superAdminsOnly[T](parser: BodyParser[T])(f: AdminInfo[T] => Result): EssentialAction =
-    superAdminsOnlyAsync(parser)(info => Future.successful(f(info)))
-  def superAdminsOnly(f: AdminInfo[AnyContent] => Result): EssentialAction =
-    superAdminsOnly(controllerComponents.parsers.anyContent)(f)
+  def superAdminsOnly[T](parser: BodyParser[T])(opName: String)(f: AdminInfo[T] => Result): EssentialAction =
+    superAdminsOnlyAsync(parser)(opName: String)(info => Future.successful(f(info)))
+  def superAdminsOnly(opName: String)(f: AdminInfo[AnyContent] => Result): EssentialAction =
+    superAdminsOnly(controllerComponents.parsers.anyContent)(opName: String)(f)
 
 }

--- a/arisia-remote/app/arisia/controllers/DiscordController.scala
+++ b/arisia-remote/app/arisia/controllers/DiscordController.scala
@@ -1,8 +1,8 @@
 package arisia.controllers
 
 import arisia.auth.LoginService
-import arisia.discord.{DiscordUserCredentials, DiscordService, DiscordHelpCredentials}
-import play.api.Configuration
+import arisia.discord.{DiscordHelpCredentials, DiscordUserCredentials, DiscordService}
+import play.api.{Configuration, Logging}
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
@@ -20,6 +20,7 @@ class DiscordController(
   with AdminControllerFuncs
   with UserFuncs
   with I18nSupport
+  with Logging
 {
   // TODO: remove this test entry point
   def test(): EssentialAction = Action.async { implicit request =>

--- a/arisia-remote/app/arisia/controllers/DuckController.scala
+++ b/arisia-remote/app/arisia/controllers/DuckController.scala
@@ -78,19 +78,19 @@ class DuckController(
     )(Duck.apply)(Duck.unapply)
   )
 
-  def manageDucks(): EssentialAction = adminsOnly { info =>
+  def manageDucks(): EssentialAction = adminsOnly("Manage Ducks") { info =>
     implicit val request = info.request
 
     val ducks = duckService.getDucks()
     Ok(arisia.views.html.manageDucks(ducks))
   }
 
-  def createDuck(): EssentialAction = adminsOnly { info =>
+  def createDuck(): EssentialAction = adminsOnly("Show Create Duck") { info =>
     implicit val request = info.request
 
     Ok(arisia.views.html.editDuck(duckForm.fill(Duck.empty)))
   }
-  def showEditDuck(id: Int): EssentialAction = adminsOnly { info =>
+  def showEditDuck(id: Int): EssentialAction = adminsOnly("Show Edit Duck") { info =>
     implicit val request = info.request
 
     val ducks = duckService.getDucks()
@@ -100,7 +100,7 @@ class DuckController(
     }
   }
 
-  def duckModified(): EssentialAction = adminsOnlyAsync { info =>
+  def duckModified(): EssentialAction = adminsOnlyAsync("Duck Modified") { info =>
     implicit val request = info.request
 
     duckForm.bindFromRequest().fold(
@@ -109,6 +109,7 @@ class DuckController(
         Future.successful(BadRequest(arisia.views.html.editDuck(formWithErrors)))
       },
       duck => {
+        info.audit(s"Duck ${duck.id}")
         val fut =
           if (duck.id == 0) {
             duckService.addDuck(duck)
@@ -123,7 +124,7 @@ class DuckController(
     )
   }
 
-  def removeDuck(id: Int): EssentialAction = adminsOnlyAsync { info =>
+  def removeDuck(id: Int): EssentialAction = adminsOnlyAsync(s"Remove Duck $id") { info =>
     duckService.removeDuck(id).map { _ =>
       Redirect(arisia.controllers.routes.DuckController.manageDucks())
     }

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -4,6 +4,7 @@ import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import arisia.auth.LoginService
 import arisia.general.{FileService, FileType}
+import play.api.Logging
 
 import scala.concurrent.ExecutionContext
 import play.api.i18n.I18nSupport
@@ -23,7 +24,9 @@ class FileController(
   implicit val ec: ExecutionContext
 ) extends BaseController
   with AdminControllerFuncs
-  with I18nSupport {
+  with I18nSupport
+  with Logging
+{
 
   def manageMetadata(): EssentialAction = Action { implicit request =>
     Ok(arisia.views.html.uploadMetadata())
@@ -41,7 +44,7 @@ class FileController(
   def multipartFormDataAsBytes: BodyParser[MultipartFormData[ByteString]] =
     controllerComponents.parsers.multipartFormData(byteStringFilePartHandler)
 
-  def uploadBase(tpe: FileType): EssentialAction = adminsOnlyAsync(multipartFormDataAsBytes) { adminInfo =>
+  def uploadBase(tpe: FileType): EssentialAction = adminsOnlyAsync(multipartFormDataAsBytes)(s"Upload ${tpe.value}") { adminInfo =>
     val request = adminInfo.request
     // Rather than farting around with the terribly sophisticated and terribly hard-to-use multipart machinery
     // built into Play, we're doing this as dead-simply as we can:

--- a/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
@@ -5,6 +5,7 @@ import java.time.{LocalDate, LocalTime}
 import arisia.auth.LoginService
 import arisia.models.{ProgramItemPersonName, ProgramItemTime, ProgramItemTag, ProgramItemDesc, ProgramItemDate, ProgramItem, ProgramItemPerson, ProgramItemId, ProgramItemLoc, ProgramItemTitle, ProgramPersonId}
 import arisia.schedule.ScheduleService
+import play.api.Logging
 import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
 import play.api.data._
 import play.api.data.Forms._
@@ -25,6 +26,7 @@ class ScheduleTestController(
 ) extends BaseController
   with AdminControllerFuncs
   with I18nSupport
+  with Logging
 {
 
   val scheduleForm = Form(
@@ -43,13 +45,13 @@ class ScheduleTestController(
     )(ScheduleInput.apply)(ScheduleInput.unapply)
   )
 
-  def showTestScheduleInput(): EssentialAction = adminsOnly { info =>
+  def showTestScheduleInput(): EssentialAction = adminsOnly("Show Test Schedule UI") { info =>
     implicit val request = info.request
 
     Ok(arisia.views.html.addTestScheduleItem(scheduleForm.fill(ScheduleInput.empty)))
   }
 
-  def addTestScheduleItem(): EssentialAction = adminsOnly { info =>
+  def addTestScheduleItem(): EssentialAction = adminsOnly(s"Add Test Schedule Item") { info =>
     implicit val request = info.request
 
     def toField[T](str: String, f: String => T): Option[T] = {
@@ -62,6 +64,7 @@ class ScheduleTestController(
     scheduleForm.bindFromRequest().fold(
       formWithErrors => BadRequest(""),
       input => {
+        info.audit(s"${input.title} at ${input.time}")
         val tags: List[ProgramItemTag] = input.tags.split(',').toList.map(ProgramItemTag(_))
         val time: Option[ProgramItemTime] =
           if (input.time.isEmpty)

--- a/arisia-remote/app/arisia/controllers/ZoomController.scala
+++ b/arisia-remote/app/arisia/controllers/ZoomController.scala
@@ -5,6 +5,7 @@ import arisia.auth.LoginService
 import arisia.models.{ProgramItemId, LoginUser, ZoomRoom}
 import arisia.schedule.ScheduleService
 import arisia.zoom.ZoomService
+import play.api.Logging
 import play.api.data._
 import play.api.data.Forms._
 import play.api.mvc.{BaseController, ControllerComponents, EssentialAction}
@@ -26,6 +27,7 @@ class ZoomController(
 ) extends BaseController
   with AdminControllerFuncs
   with I18nSupport
+  with Logging
 {
 
   // TODO: get rid of this. There isn't much harm to it, but we won't need it once integration is really working,
@@ -84,19 +86,19 @@ class ZoomController(
     )(ZoomRoom.apply)(ZoomRoom.unapply)
   )
 
-  def manageZoomRooms(): EssentialAction = superAdminsOnly { info =>
+  def manageZoomRooms(): EssentialAction = superAdminsOnly("Manage Zoom Rooms") { info =>
     implicit val request = info.request
 
     val rooms = roomService.getRooms()
     Ok(arisia.views.html.manageZoomRooms(rooms))
   }
 
-  def createRoom(): EssentialAction = superAdminsOnly { info =>
+  def createRoom(): EssentialAction = superAdminsOnly("Show Create Room") { info =>
     implicit val request = info.request
 
     Ok(arisia.views.html.editRoom(roomForm.fill(ZoomRoom.empty)))
   }
-  def showEditRoom(id: Int): EssentialAction = superAdminsOnly { info =>
+  def showEditRoom(id: Int): EssentialAction = superAdminsOnly(s"Show Edit Room $id") { info =>
     implicit val request = info.request
 
     val rooms = roomService.getRooms()
@@ -106,7 +108,7 @@ class ZoomController(
     }
   }
 
-  def roomModified(): EssentialAction = superAdminsOnlyAsync { info =>
+  def roomModified(): EssentialAction = superAdminsOnlyAsync("Room Modified") { info =>
     implicit val request = info.request
 
     roomForm.bindFromRequest().fold(
@@ -115,6 +117,7 @@ class ZoomController(
         Future.successful(BadRequest(arisia.views.html.editRoom(formWithErrors)))
       },
       room => {
+        info.audit(s"Room ${room.id} (${room.zambiaName})")
         val fut =
           if (room.id == 0) {
             roomService.addRoom(room)
@@ -129,7 +132,7 @@ class ZoomController(
     )
   }
 
-  def removeRoom(id: Int): EssentialAction = adminsOnlyAsync { info =>
+  def removeRoom(id: Int): EssentialAction = adminsOnlyAsync(s"Remove Room $id") { info =>
     roomService.removeRoom(id).map { _ =>
       Redirect(arisia.controllers.routes.ZoomController.manageZoomRooms())
     }


### PR DESCRIPTION
It ain't fancy, but it at least shows us any time an Admin is poking around, and what they are doing.

Coded such that you *have* to have auditing if you are following the standard Admin UI controller patterns, to prevent accidentally forgetting an entry point. This means that even looking at Admin pages will be audited -- not a bad thing on general principles.

Fixes #145 