### PR TITLE
Backend hooks for working with "manual" meetings

### DIFF
--- a/arisia-remote/app/arisia/admin/RoomService.scala
+++ b/arisia-remote/app/arisia/admin/RoomService.scala
@@ -22,6 +22,8 @@ trait RoomService {
   def removeRoom(id: Int): Future[Done]
 
   def getRoomForZambia(loc: ProgramItemLoc): Future[Option[ZoomRoom]]
+
+  def getManualRoom(name: String): Option[ZoomRoom]
 }
 
 class RoomServiceImpl(
@@ -100,5 +102,9 @@ class RoomServiceImpl(
         .update
         .run
     ).flatMap(_ => loadRooms())
+  }
+
+  def getManualRoom(name: String): Option[ZoomRoom] = {
+    _roomCache.get().find(room => room.isManual && room.zambiaName == name)
   }
 }

--- a/arisia-remote/app/arisia/views/editRoom.scala.html
+++ b/arisia-remote/app/arisia/views/editRoom.scala.html
@@ -17,8 +17,8 @@
   @b4.horizontal.form(arisia.controllers.routes.ZoomController.roomModified(), "col-md-2", "col-md-10") { implicit hfc =>
     @b4.text(roomForm("id"), Symbol("_label") -> "ID", Symbol("readonly") -> true)
     @b4.text(roomForm("displayName"), Symbol("_label") -> "Display Name")
-    @b4.text(roomForm("zoomId"), Symbol("_label") -> "Zoom User ID")
-    @b4.text(roomForm("zambiaName"), Symbol("_label") -> "Zambia Room Name")
+    @b4.text(roomForm("zoomId"), Symbol("_label") -> "Zoom User ID (or meeting ID)")
+    @b4.text(roomForm("zambiaName"), Symbol("_label") -> "Zambia Room Name (or public name)")
     @b4.text(roomForm("discordName"), Symbol("_label") -> "Discord Channel")
     @b4.checkbox(roomForm("isManual"), Symbol("_label") -> "Non-Scheduled Room")
     @b4.checkbox(roomForm("isWebinar"), Symbol("_label") -> "Zoom Webinar")

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -21,6 +21,29 @@ POST    /api/login                   arisia.controllers.LoginController.login()
 
 GET     /api/me                      arisia.controllers.LoginController.me()
 
+###
+#  summary: is this room open?
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/room/open/:name         arisia.controllers.ZoomController.isRoomOpen(name)
+
+###
+#  summary: go to this room
+#  responses:
+#    303:
+#      description: Redirect
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/room/enter/:name        arisia.controllers.ZoomController.goToRoom(name)
 
 ###
 #  summary: fetch the specified frontend config entry
@@ -221,7 +244,7 @@ GET     /admin/assets/*file          controllers.Assets.versioned(path="/public"
 # Zambia emulator, providing test data
 GET     /test/fakeschedule           arisia.controllers.FakeZambiaController.getSchedule()
 # TODO: remove
-GET     /test/zoomcall               arisia.controllers.ZoomController.test()
+GET     /test/zoomcall/:id               arisia.controllers.ZoomController.test(id: Long)
 # TODO: remove
 GET     /test/getDiscordMembers      arisia.controllers.DiscordController.test()
 GET     /test/scheduleItem           arisia.controllers.ScheduleTestController.showTestScheduleInput()


### PR DESCRIPTION
(Draft: there is time to change this, but let's be concrete about it.)

We have a lot of Zoom spaces that are *not* scheduled (eg, Gaming, Social, Youth), and so don't fit into the framework so far. These meetings are owned by their respective divisions, who will be empowered to open and close the rooms when they see fit. (We will use the "personal meeting" attached to each account, because that is by far the easiest way to deal with it.)

So this adds two new entry points to allow the frontend to allow users into those rooms when appropriate:
```
GET /api/room/open/:name
GET /api/room/enter/:name
```
In both cases, we will agree on the value of `name` -- probably something like `gaming`, `social`, etc. (The backend values are configured in the Admin UI, so the UI can set what it likes.)

The `open` entry point returns:
```
{"running":true}
or
{"running":false}
```
To indicate whether this space is currently open; if not, it should tell the user in some fashion that the room is currently closed.

Assuming the user is logged in, and the room is open, the frontend should open a new tab calling the `enter` entry point, and it will redirect to the Zoom meeting as usual.

Fixes #274 