### PR TITLE
Add Discord Sync

### DIFF
--- a/arisia-remote/app/arisia/controllers/DiscordController.scala
+++ b/arisia-remote/app/arisia/controllers/DiscordController.scala
@@ -75,4 +75,22 @@ class DiscordController(
       case _ => Future.successful(Unauthorized("Shared secret not found in the X-Shared"))
     }
   }
+
+  def sync(id: String): EssentialAction = Action.async { implicit request =>
+    request.headers.get("X-Shared-Secret") match {
+      case Some(secret) if (secret == sharedSecret) => {
+        loginService.fetchUserFromDiscordId(id).flatMap {
+          _ match {
+            case Some(user) => {
+              discordService.syncUser(user, id).map { _ =>
+                Ok("")
+              }
+            }
+            case _ => Future.successful(NotFound("Not a known Discord user!"))
+          }
+        }
+      }
+      case _ => Future.successful(Unauthorized("Shared secret not found in the X-Shared"))
+    }
+  }
 }

--- a/arisia-remote/conf/evolutions/default/12.sql
+++ b/arisia-remote/conf/evolutions/default/12.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+CREATE INDEX discord_id_index ON user_info (discord_id);
+
+-- !Downs
+
+DROP INDEX discord_id_index;

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -207,6 +207,22 @@ GET     /api/discord/getAssistSecret arisia.controllers.DiscordController.genera
 #      description: passed-in info not valid
 ###
 POST    /api/discord/assistAddArisian arisia.controllers.DiscordController.assistedAddArisian()
+###
+#  summary: via Lambda, sync this Discord user with their current info
+#  parameters:
+#    - in: header
+#      name: X-Shared-Secret
+#      schema:
+#        type: string
+#  responses:
+#    200:
+#      description: success
+#    401:
+#      description: shared secret header not found
+#    400:
+#      description: passed-in info not valid
+###
+PUT     /api/discord/sync/:id         arisia.controllers.DiscordController.sync(id)
 
 # Admin UI, separate from the attendee-facing site
 GET     /admin                       arisia.controllers.AdminController.home()


### PR DESCRIPTION
This is the third backend story for Discord. Adds a new entry point:
```
PUT /api/discord/sync/:id
```
Note that the `X-Shared-Secret` header must be set: this is intended only for use from Lambda.

The `:id` should be the Discord ID of a member who has already connected from Virtual Arisia to Discord. It will resync their info -- in practice for now, it resyncs their Badge Name.

Not well-tested, because it is unfortunately difficult to use my Discord account for testing. (Since I'm a Site Admin, bot changes to me tend to be rejected by Discord.)

Fixes #284 