### PR TITLE
Manage Coffee Shop Line metadata

### DIFF
--- a/arisia-remote/app/arisia/auth/MembershipType.scala
+++ b/arisia-remote/app/arisia/auth/MembershipType.scala
@@ -53,6 +53,7 @@ object MembershipType extends StringEnum[MembershipType] {
   case object RolloverComp extends MembershipType("CMPROL", Comp)
   case object GamingComp extends MembershipType("CMPGAM", Comp)
   case object GOHComp extends MembershipType("CMPGOH", Comp)
+  case object MiscComp extends MembershipType("CMPMSC", Comp)
 
   val values = findValues
 

--- a/arisia-remote/app/arisia/controllers/FileController.scala
+++ b/arisia-remote/app/arisia/controllers/FileController.scala
@@ -62,6 +62,7 @@ class FileController(
   def uploadDealersMetadata(): EssentialAction = uploadBase(FileType.DealersMetadata)
   def uploadGamingMetadata(): EssentialAction = uploadBase(FileType.GamingMetadata)
   def uploadEventsMetadata(): EssentialAction = uploadBase(FileType.EventsMetadata)
+  def uploadCoffeeMetadata(): EssentialAction = uploadBase(FileType.CoffeeShopMetadata)
 
   def getMetadataBase(tpe: FileType): EssentialAction = Action.async { implicit request =>
     fileService.getFile(tpe).map {
@@ -76,5 +77,6 @@ class FileController(
   def getDealersMetadata(): EssentialAction = getMetadataBase(FileType.DealersMetadata)
   def getGamingMetadata(): EssentialAction = getMetadataBase(FileType.GamingMetadata)
   def getEventsMetadata(): EssentialAction = getMetadataBase(FileType.EventsMetadata)
+  def getCoffeeMetadata(): EssentialAction = getMetadataBase(FileType.CoffeeShopMetadata)
 
 }

--- a/arisia-remote/app/arisia/general/FileType.scala
+++ b/arisia-remote/app/arisia/general/FileType.scala
@@ -9,6 +9,7 @@ object FileType extends StringPlayEnum[FileType] {
   case object DealersMetadata extends FileType("dealers")
   case object GamingMetadata extends FileType("gaming")
   case object EventsMetadata extends FileType("events")
+  case object CoffeeShopMetadata extends FileType("coffeeshop")
 
   val values = findValues
 }

--- a/arisia-remote/app/arisia/views/uploadMetadata.scala.html
+++ b/arisia-remote/app/arisia/views/uploadMetadata.scala.html
@@ -47,4 +47,13 @@ implicit request: RequestHeader, messagesProvider: MessagesProvider
       <input type="submit">
     </p>
   }
+
+  <h2>Coffee Shop Line Metadata</h2>
+
+  @helper.form(action = arisia.controllers.routes.FileController.uploadCoffeeMetadata(), Symbol("enctype") -> "multipart/form-data") {
+    <input type="file" name="events">
+    <p>
+      <input type="submit">
+    </p>
+  }
 }

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -171,6 +171,18 @@ GET     /api/metadata/gaming        arisia.controllers.FileController.getGamingM
 GET     /api/metadata/events        arisia.controllers.FileController.getEventsMetadata()
 
 ###
+#  summary: fetch the metadata for Coffee Shop Line
+#  responses:
+#    200:
+#      description: OK
+#      content:
+#        text/plain:
+#          schema:
+#            type: string
+###
+GET     /api/metadata/coffee        arisia.controllers.FileController.getCoffeeMetadata()
+
+###
 #  summary: make this person an Arisian
 #  parameters:
 #    - name: body
@@ -252,6 +264,7 @@ POST    /admin/uploadArtshowMetadata arisia.controllers.FileController.uploadArt
 POST    /admin/uploadDealersMetadata arisia.controllers.FileController.uploadDealersMetadata()
 POST    /admin/uploadGamingMetadata  arisia.controllers.FileController.uploadGamingMetadata()
 POST    /admin/uploadEventsMetadata  arisia.controllers.FileController.uploadEventsMetadata()
+POST    /admin/uploadCoffeeMetadata  arisia.controllers.FileController.uploadCoffeeMetadata()
 
 # Note the non-standard path, which is configured in application.conf, so that frontend
 # can own /assets


### PR DESCRIPTION
This provides the upload and download for the Coffee Shop Line metadata, same as for the other metadata types.

Also, adds the CMPMSC MembershipType, which we turn out to need.

Fixes #313 