### PR TITLE
Lift upload limits

### DIFF
--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -13,6 +13,10 @@ db.default.driver = org.postgresql.Driver
 # stuff:
 play.assets.urlPrefix = "/admin/assets"
 
+# These appear to be needed on Production, but not in Dev, for some reason:
+play.http.parser.maxDiskBuffer = 10MB
+parsers.anyContent.maxLength = 10MB
+
 arisia {
   # Set this to false to open the doors to the public:
   early.access.only = true


### PR DESCRIPTION
We hit a weird error on production when trying to upload a 145k file. It looks like this *could* happen from Play (although it hasn't been doing so in Dev). This adds a couple of config values that should raise the limit to 10MB, if that's where the problem is coming from.