### PR TITLE
Provide a way to restart meetings

### DIFF
--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -22,4 +22,5 @@
   <h2><a href="/admin/ducks">Manage Ducks</a></h2>
   <h2><a href="/test/scheduleItem">Add Test Schedule Item</a></h2>
   <h2><a href="/admin/manageMetadata">Manage Metadata</a></h2>
+  <h2><a href="/admin/restart">Restart Meeting</a></h2>
 }

--- a/arisia-remote/app/arisia/views/restartMeeting.scala.html
+++ b/arisia-remote/app/arisia/views/restartMeeting.scala.html
@@ -1,0 +1,15 @@
+@(
+  form: Form[String]
+)(implicit request: RequestHeader, messagesProvider: MessagesProvider)
+
+@main("Restart Meeting") {
+  <h1>Restart Meeting</h1>
+
+  <p>This should only be used in the extreme case where a Zoom Host has accidentally shut a Program Item down
+  prematurely. In that case, put the item's ID (the number identifying it in the schedule) here, to reboot
+  the Zoom meeting.</p>
+
+  @b4.horizontal.form(arisia.controllers.routes.ZoomController.restartProgramItem(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(form("itemId"), Symbol("_label") -> "Program Item ID")
+  }
+}

--- a/arisia-remote/app/arisia/zoom/ZoomService.scala
+++ b/arisia-remote/app/arisia/zoom/ZoomService.scala
@@ -105,8 +105,10 @@ class ZoomServiceImpl(
       .get()
       .map { response =>
         val json = Json.parse(response.body)
-        val status = (json \ "status").as[String]
-        (status == "started")
+        (json \ "status").asOpt[String] match {
+          case Some(status) => (status == "started")
+          case _ => false
+        }
       }
   }
 

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -259,6 +259,9 @@ DELETE  /admin/rooms/:id             arisia.controllers.ZoomController.removeRoo
 POST    /admin/meeting               arisia.controllers.AdminController.startMeeting()
 DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeting(meetingId)
 
+GET     /admin/restart               arisia.controllers.ZoomController.showRestart()
+POST    /admin/restart               arisia.controllers.ZoomController.restartProgramItem()
+
 GET     /admin/manageMetadata        arisia.controllers.FileController.manageMetadata()
 POST    /admin/uploadArtshowMetadata arisia.controllers.FileController.uploadArtshowMetadata()
 POST    /admin/uploadDealersMetadata arisia.controllers.FileController.uploadDealersMetadata()


### PR DESCRIPTION
There is a failure mode we have to deal with: the Host does the wrong thing, and shuts down a program item prematurely. At that point, the Zoom meeting is dead -- everyone is kicked out, and nobody (including the Host) can re-enter.

So this adds a new Admin UI page for this emergency. Give it the item number for a program item in this state, and it will properly close the original version, start up a new meeting, and rewire everything. At that point, the Host can re-enter, and then the participants.

Fixes #265