### PR TITLE
Get Webinars working

### DIFF
--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -52,7 +52,7 @@ class AdminController (
    */
   def startMeeting(): EssentialAction = adminsOnlyAsync("Started test meeting") { info =>
     val userId = config.get[String]("arisia.zoom.api.userId")
-    zoomService.startMeeting("Ad hoc meeting", userId).map { errorOrMeeting =>
+    zoomService.startMeeting("Ad hoc meeting", userId, false).map { errorOrMeeting =>
       errorOrMeeting match {
         case Right(meeting) => Ok(Json.toJson(meeting).toString())
         case Left(error) => InternalServerError(error)
@@ -63,7 +63,7 @@ class AdminController (
   def endMeeting(meetingIdStr: String): EssentialAction = adminsOnlyAsync("Ended meeting manually") { info =>
     meetingIdStr.toLongOption match {
       case Some(meetingId) => {
-        zoomService.endMeeting(meetingId).map { _ =>
+        zoomService.endMeeting(meetingId, false).map { _ =>
           Ok(s"Meeting $meetingId ended")
         }
       }

--- a/arisia-remote/app/arisia/controllers/ZoomController.scala
+++ b/arisia-remote/app/arisia/controllers/ZoomController.scala
@@ -95,7 +95,14 @@ class ZoomController(
 
     scheduleQueueService.getRunningMeeting(itemId) match {
       case Some(meeting) => {
-        zoomService.isMeetingRunning(meeting.id).flatMap { running =>
+        val checkRunning: Future[Boolean] =
+          if (meeting.isWebinar)
+            // Sadly, we don't appear to have a way to check this for webinars, so we're just going to cross
+            // our fingers and hope for the best:
+            Future.successful(false)
+          else
+            zoomService.isMeetingRunning(meeting.id)
+        checkRunning.flatMap { running =>
           if (running) {
             // TODO: think about this. If the meeting is running and somebody tries to use this API, should
             // we stomp the existing meeting? It could conceivably happen in case of a takeover. We do have

--- a/arisia-remote/app/arisia/zoom/models/ZoomMeeting.scala
+++ b/arisia-remote/app/arisia/zoom/models/ZoomMeeting.scala
@@ -12,8 +12,11 @@ import play.api.libs.json.{Format, Json}
 case class ZoomMeeting(
   id: Long,
   start_url: String,
-  join_url: String
-)
+  join_url: String,
+  `type`: Int
+) {
+  def isWebinar: Boolean = `type` == ZoomMeetingType.Webinar
+}
 object ZoomMeeting {
   implicit val fmt: Format[ZoomMeeting] = Json.format
 }
@@ -22,5 +25,8 @@ object ZoomMeetingType {
   final val Instant = 1
   final val Scheduled = 2
   final val RecurringUnfixed = 3
+  final val Webinar = 5
+  final val WebinarRecurringUnfixed = 6
   final val RecurringFixed = 8
+  final val WebinarRecurringFixed = 9
 }

--- a/arisia-remote/conf/evolutions/default/13.sql
+++ b/arisia-remote/conf/evolutions/default/13.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+ALTER TABLE active_program_items ADD COLUMN webinar boolean DEFAULT FALSE NOT NULL;
+
+-- !Downs
+
+ALTER TABLE active_program_items DROP COLUMN webinar;


### PR DESCRIPTION
While Zoom's API is mostly nice, it does have a deep stupidity that the entry points for Meetings and Webinars are completely unrelated, even though they do almost exactly the same things.

So this propagates through the concept of whether a given program item is a Webinar or not, and calls the appropriate entry points depending on the answer.

Fixes #217 