### PR TITLE
Better login errors

### DIFF
--- a/arisia-remote/app/arisia/auth/CMService.scala
+++ b/arisia-remote/app/arisia/auth/CMService.scala
@@ -91,6 +91,8 @@ class CMServiceImpl(
         if (body.contains("Bad username or password")) {
           // CM says that it's wrong:
           Left(LoginError.NoLogin)
+        } else if (body.contains("Your password has expired")) {
+          Left(LoginError.PasswordReset)
         } else if (body.contains("Please Double-check your name information")) {
           // That indicates that CM thinks it's a legit username/password
           // Parse out the badgename. We're not even going to try and be cute about this

--- a/arisia-remote/app/arisia/auth/LoginError.scala
+++ b/arisia-remote/app/arisia/auth/LoginError.scala
@@ -6,13 +6,15 @@ sealed abstract class LoginError(val value: String) extends StringEnumEntry
 
 object LoginError extends StringPlayEnum[LoginError] {
   // This username/password combination isn't found in CM
-  case object NoLogin extends LoginError("nologin")
+  case object NoLogin extends LoginError("An error has occurred during log in. Please check your username and password at https://reg.arisia.org. For help, please email registration@arisia.org")
   // This account doesn't have a membership for this year
-  case object NoMembership extends LoginError("nomembership")
+  case object NoMembership extends LoginError("Oops! It appears you don’t have a convention membership for 2021. Please go to https://reg.arisia.org to register for Arisia 2021. Note that the deadline has passed for rollovers, but registration is still available.")
   // This person hasn't signed the current Code of Conduct
-  case object NoCoC extends LoginError("nococ")
+  case object NoCoC extends LoginError("It is mandatory that all participants at Arisia understand and sign the Code of Conduct. Please do so at https://reg.arisia.org. For help, please email registration@arisia.org")
   // This person isn't allowed into the site yet
-  case object NotYet extends LoginError("notyet")
+  case object NotYet extends LoginError("Too soon! Virtual Arisia isn’t open yet, but will be soon! Please check the Schedule at https://www.arisia.org/Publications#Schedule.")
+  // This person's password has been reset
+  case object PasswordReset extends LoginError("Your password has expired. Please go to https://reg.arisia.org and follow the instructions to reset your password. If you have issues doing so, please email registration@arisia.org.")
 
   val values = findValues
 }


### PR DESCRIPTION
Instead of sending an enumeration to the frontend on login failure, we send the full text to render.

This also adds another error case: this user's password has expired, so they need to go to Registration to fix it.

Fixes the backend side of #369, but the frontend needs to pick that up and show the messages.