### PR TITLE
Pre-star program items where I am a participant

### DIFF
--- a/arisia-remote/app/arisia/controllers/ScheduleController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleController.scala
@@ -61,7 +61,21 @@ class ScheduleController(
 
   def getStars(): EssentialAction = withLoggedInAsync { info =>
     starService.getStars(info.who.id).map { stars =>
-      Ok(Json.toJson(stars).toString())
+      val preAssignedStars: List[ProgramItemId] = {
+        val schedule = scheduleService.currentSchedule()
+        val myBadgeNumber = info.who.badgeNumber
+        if (schedule.participants.contains(myBadgeNumber)) {
+          schedule.program
+            .filter { item =>
+              item.people.exists(_.id.matches(myBadgeNumber))
+            }
+            .map(_.id)
+        } else {
+          List.empty
+        }
+      }
+      val allStars: Set[ProgramItemId] = stars.toSet ++ preAssignedStars
+      Ok(Json.toJson(allStars).toString())
     }
   }
 }

--- a/arisia-remote/app/arisia/timer/TimerService.scala
+++ b/arisia-remote/app/arisia/timer/TimerService.scala
@@ -40,7 +40,7 @@ class TimerServiceImpl(
     cb: Instant => Unit
   ) extends Runnable {
     def run(): Unit = {
-      logger.info(s"Tick: running $name")
+      logger.debug(s"Tick: running $name")
       cb(time.now())
     }
 

--- a/arisia-remote/conf/logback.xml
+++ b/arisia-remote/conf/logback.xml
@@ -32,7 +32,7 @@
   </appender>
 
   <logger name="play" level="INFO" />
-  <logger name="arisia" level="DEBUG" />
+  <logger name="arisia" level="INFO" />
 
   <root level="WARN">
     <appender-ref ref="ASYNCFILE" />


### PR DESCRIPTION
This makes My Schedule much more useful for program participants: they don't have to go find and star their stuff manually.

Also, turned logging down slightly, to reduce log spam. (In particular, the Timer no longer spams the log by default.)

Fixes #370 