### PR TITLE
Put a real secret in place for the assisted-Discord flow

### DIFF
--- a/arisia-remote/test/arisia/discord/DiscordServiceSpec.scala
+++ b/arisia-remote/test/arisia/discord/DiscordServiceSpec.scala
@@ -1,0 +1,23 @@
+package arisia.discord
+
+import arisia.auth.MembershipType
+import arisia.models.{BadgeNumber, LoginName, LoginUser, LoginId}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DiscordServiceSpec extends AnyWordSpec with Matchers {
+  "DiscordService" should {
+    "be able to generate and validate secrets" in {
+      val user = LoginUser(
+        LoginId("foo"),
+        LoginName("Foo Bar"),
+        BadgeNumber("29309"),
+        false,
+        MembershipType.AdultStandard
+      )
+      val secretKey = "lsdflisdpisdf;kasd;lkas;lk"
+      val secret = DiscordService.generateAssistSecret(secretKey)(user)
+      DiscordService.validateAssistSecret(secretKey)(secret) shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
Instead of the unchecked fake secret (which allowed abuse), this replaces it with something that is decently cryptographically sound. Requires the user to copy/paste (it's too long to retype), but Gail indicated that was okay.

Fixes #298 