### PR TITLE
Switch the security encoding

### DIFF
--- a/arisia-remote/test/arisia/discord/DiscordServiceSpec.scala
+++ b/arisia-remote/test/arisia/discord/DiscordServiceSpec.scala
@@ -11,12 +11,13 @@ class DiscordServiceSpec extends AnyWordSpec with Matchers {
       val user = LoginUser(
         LoginId("foo"),
         LoginName("Foo Bar"),
-        BadgeNumber("29309"),
+        BadgeNumber("129230"),
         false,
         MembershipType.AdultStandard
       )
       val secretKey = "lsdflisdpisdf;kasd;lkas;lk"
       val secret = DiscordService.generateAssistSecret(secretKey)(user)
+      println(secret)
       DiscordService.validateAssistSecret(secretKey)(secret) shouldBe true
     }
   }


### PR DESCRIPTION
Going to a somewhat less-secure (but still probably good enough) hash, and switch from hex to base64, to bring down the length of the resulting string.