### PR TITLE
Get Manual Meeting Start URLs

### DIFF
--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -23,4 +23,5 @@
   <h2><a href="/test/scheduleItem">Add Test Schedule Item</a></h2>
   <h2><a href="/admin/manageMetadata">Manage Metadata</a></h2>
   <h2><a href="/admin/restart">Restart Meeting</a></h2>
+  <h2><a href="/admin/showStartUrl">Get Start URL for Manually-managed Rooms</a></h2>
 }

--- a/arisia-remote/app/arisia/views/showMeetingUrl.scala.html
+++ b/arisia-remote/app/arisia/views/showMeetingUrl.scala.html
@@ -1,0 +1,11 @@
+@(name: String, url: String)
+
+@main("Start Meeting URL") {
+  <h1>Start Meeting URL</h1>
+
+  <p>The Start Meeting URL for @name is <a href="@url" target="_blank">@url</a></p>
+
+  <p><b>This must only be shared with trusted members of the appropriate division!</b></p>
+
+  <p><a href="/admin">Back to Admin Home</a></p>
+}

--- a/arisia-remote/app/arisia/views/showMeetingUrlInput.scala.html
+++ b/arisia-remote/app/arisia/views/showMeetingUrlInput.scala.html
@@ -1,0 +1,16 @@
+@(
+  form: Form[String]
+)(implicit request: RequestHeader, messagesProvider: MessagesProvider)
+
+@main("Show Start Meeting URL") {
+  <h1>Show Start Meeting URL</h1>
+
+  <p>Given the name of an area that has a static room, this lets you grab the Start URL for that room. This URL
+  can then be shared with <b>trusted Hosts</b>, who will then have the power to start that meeting as needed.</p>
+
+  <p><b>IMPORTANT: do not use this for rooms on the Schedule! You can break the site by abusing this!</b></p>
+
+  @b4.horizontal.form(arisia.controllers.routes.ZoomController.getStartUrl(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(form("name"), Symbol("_label") -> "Room Name")
+  }
+}

--- a/arisia-remote/app/arisia/zoom/ZoomService.scala
+++ b/arisia-remote/app/arisia/zoom/ZoomService.scala
@@ -24,6 +24,7 @@ trait ZoomService {
   // Note that this can't be used with Webinars!
   def isMeetingRunning(meetingId: Long): Future[Boolean]
   def getJoinUrl(meetingId: Long): Future[String]
+  def getStartUrl(meetingId: Long): Future[String]
 }
 
 private[zoom] case class ZoomMeetingParams(
@@ -135,6 +136,16 @@ class ZoomServiceImpl(
         result
       }
   }
+
+  def getStartUrl(meetingId: Long): Future[String] = {
+    urlWithJwt(s"/meetings/$meetingId")
+      .get()
+      .map { response =>
+        val json = Json.parse(response.body)
+        val result = (json \ "start_url").as[String]
+        result
+      }
+  }
 }
 
 class DisabledZoomService() extends ZoomService {
@@ -143,4 +154,5 @@ class DisabledZoomService() extends ZoomService {
   def endMeeting(meetingId: Long, isWebinar: Boolean): Future[Done] = ???
   def isMeetingRunning(meetingId: Long): Future[Boolean] = ???
   def getJoinUrl(meetingId: Long): Future[String] = ???
+  def getStartUrl(meetingId: Long): Future[String] = ???
 }

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -262,6 +262,9 @@ DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeti
 GET     /admin/restart               arisia.controllers.ZoomController.showRestart()
 POST    /admin/restart               arisia.controllers.ZoomController.restartProgramItem()
 
+GET     /admin/showStartUrl          arisia.controllers.ZoomController.showGetStartUrl()
+POST    /admin/showStartUrl          arisia.controllers.ZoomController.getStartUrl()
+
 GET     /admin/manageMetadata        arisia.controllers.FileController.manageMetadata()
 POST    /admin/uploadArtshowMetadata arisia.controllers.FileController.uploadArtshowMetadata()
 POST    /admin/uploadDealersMetadata arisia.controllers.FileController.uploadDealersMetadata()


### PR DESCRIPTION
We need to be able to get the magic Start URLs for the manually-managed meetings, so that people other than the account owner can start them. This provides an admin interface that, given the standardized name for the meeting (eg, "social"), hands you back the Start URL, which can be used immediately or shared around.