### PR TITLE
Restrict access to test meetings

### DIFF
--- a/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleTestController.scala
@@ -45,13 +45,13 @@ class ScheduleTestController(
     )(ScheduleInput.apply)(ScheduleInput.unapply)
   )
 
-  def showTestScheduleInput(): EssentialAction = adminsOnly("Show Test Schedule UI") { info =>
+  def showTestScheduleInput(): EssentialAction = superAdminsOnly("Show Test Schedule UI") { info =>
     implicit val request = info.request
 
     Ok(arisia.views.html.addTestScheduleItem(scheduleForm.fill(ScheduleInput.empty)))
   }
 
-  def addTestScheduleItem(): EssentialAction = adminsOnly(s"Add Test Schedule Item") { info =>
+  def addTestScheduleItem(): EssentialAction = superAdminsOnly(s"Add Test Schedule Item") { info =>
     implicit val request = info.request
 
     def toField[T](str: String, f: String => T): Option[T] = {

--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -15,12 +15,12 @@
   @if(permissions.superAdmin) {
     <h2><a href="/admin/manageAdmins">Manage Admins</a></h2>
     <h2><a href="/admin/rooms">Manage Zoom Rooms</a></h2>
+    <h2><a href="/test/scheduleItem">Add Test Schedule Item</a></h2>
   }
 
   <h2><a href="/admin/manageEarlyAccess">Manage Early Access</a></h2>
   <h2><a href="/admin/manageTech">Manage Tech</a></h2>
   <h2><a href="/admin/ducks">Manage Ducks</a></h2>
-  <h2><a href="/test/scheduleItem">Add Test Schedule Item</a></h2>
   <h2><a href="/admin/manageMetadata">Manage Metadata</a></h2>
   <h2><a href="/admin/restart">Restart Meeting</a></h2>
   <h2><a href="/admin/showStartUrl">Get Start URL for Manually-managed Rooms</a></h2>


### PR DESCRIPTION
This mechanism was created for my own test purposes, and I still need it for that in local dev. But it causes problems on the live site, so we shouldn't be allowing people to use it.

This should be merged later this evening, once Tech is done with training.