### PR TITLE
Hopefully a fix to the Discord rate limiting

### DIFF
--- a/arisia-remote/app/arisia/auth/MembershipType.scala
+++ b/arisia-remote/app/arisia/auth/MembershipType.scala
@@ -46,6 +46,7 @@ object MembershipType extends StringEnum[MembershipType] {
   case object Student extends MembershipType("STDNT", UnknownAge)
   case object StudentYA extends MembershipType("STDYA", Teen)
   case object TTYA extends MembershipType("TTYA", Teen)
+  case object AdultRollover extends MembershipType("ADROLL", Adult)
 
   // Comps:
   case object EarnedComp extends MembershipType("CMPERN", Comp)

--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -70,6 +70,8 @@ arisia {
       page.size = 100
       # The shared secret between the Lambda side of Arisiabot and this
       shared.secret = "fakesecret"
+      # How often to load members
+      load.members.interval = 5m
     }
   }
 


### PR DESCRIPTION
We are getting rate-limited on the load-members call. So switching that to poll every five minutes, instead of doing it on demand.

Hopefully this works -- we're all clogged up now, so I can't properly test.

Also add the Adult Rollover membership type.

Fixes #389 
Fixes #428 