### PR TITLE
Separate ETags for Hosts from those for everyone else

### DIFF
--- a/arisia-remote/app/arisia/controllers/ScheduleController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleController.scala
@@ -18,7 +18,13 @@ class ScheduleController(
 {
   def getSchedule(): EssentialAction = Action { implicit request =>
     val userOpt = LoginController.loggedInUser()
-    val currentSchedule = scheduleService.currentSchedule()
+    val isHost = userOpt.map(_.zoomHost).getOrElse(false)
+    val currentSchedule =
+      if (isHost)
+        scheduleService.fullSchedule()
+      else
+        scheduleService.currentSchedule()
+
     // The HTTP standard says that the hash should be in double-quotes in both directions:
     //   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
     // Note that the hash is always derived from the current schedule -- the others are based on it, so we


### PR DESCRIPTION
Fixes a problem Chris pointed out several days ago, which I failed to find time to investigate. This should solve the problem when people are added/removed as Tech during the con -- it produces a different ETag in those situations.

(I believe it's a non-issue when someone's Program Participant status changes: that implies a change to the Schedule, so the ETags will be invalidated anyway.)

Fixes #341 