### PR TITLE
Redirect FastTrack panels into the Youth Services Zoom

### DIFF
--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -75,6 +75,12 @@ arisia {
     }
   }
 
+  fasttrack {
+    # This section is for the Fast Track hack: all FT panels actually happen in the Youth Services room:
+    zambia.name = "FastTrack Zoom"
+    zoom.name = "youth"
+  }
+
   frontend {
     # This section is entirely for quasi-secrets desired by the frontend. The backend code does not refer to any
     # of them explicitly; the frontend team should feel free to add entries here as desired. They will all be


### PR DESCRIPTION
Fast Track is a funny case: unlike most of our programming, with individually-created meetings for everything, it's just a breakout room in Youth Services.

So this little hack intercepts all attempts to enter Fast Track panels, and instead routes them to the Youth Services Zoom. Not the prettiest thing in the world, but it ought to work.

This requires some configuration on the live site, to hook the pieces together; I will deal with that after we deploy this.

Fixes #408 