### PR TITLE
Fix the Fast Track link

### DIFF
--- a/arisia-remote/conf/application.conf
+++ b/arisia-remote/conf/application.conf
@@ -77,7 +77,7 @@ arisia {
 
   fasttrack {
     # This section is for the Fast Track hack: all FT panels actually happen in the Youth Services room:
-    zambia.name = "FastTrack Zoom"
+    zambia.name = "Fast Track"
     zoom.name = "youth"
   }
 


### PR DESCRIPTION
Somehow, I had gotten the idea that Fast Track had the location "FastTrack Zoom" in Zambia, but that appears to not be correct. Fixing this to detect the right sessions.