### PR TITLE
Fix the Fast Track link

### DIFF
--- a/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
@@ -57,7 +57,7 @@ class ScheduleQueueServiceImpl(
   override def init() = {
 
     // On a regular basis, check whether we need to start/stop Zoom sessions
-    timerService.register("Schedule Queue Service", queueCheckInterval)(checkQueues)
+//    timerService.register("Schedule Queue Service", queueCheckInterval)(checkQueues)
 
     dbService.run(
       sql"""


### PR DESCRIPTION
Somehow, I had gotten the idea that Fast Track had the location "FastTrack Zoom" in Zambia, but that appears to not be correct. Fixing this to detect the right sessions.