### PR TITLE
Fix The Incredibly Stupid Cursor Bug

### DIFF
--- a/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
@@ -34,6 +34,7 @@ trait ScheduleQueueService {
 class ScheduleQueueServiceImpl(
   dbService: DBService,
   timerService: TimerService,
+  time: TimeService,
   config: Configuration,
   roomService: RoomService,
   zoomService: ZoomService,
@@ -107,6 +108,7 @@ class ScheduleQueueServiceImpl(
   }
 
   def setScheduleCursor(now: Long): Future[Int] = {
+    _scheduleCursor.set(now)
     dbService.run(
       sql"""INSERT INTO text_files
                  (name, value)
@@ -142,9 +144,16 @@ class ScheduleQueueServiceImpl(
             // Only bother with items whose time is after our last processing time:
             item.zoomStart.get.toLong > _scheduleCursor.get()
           }
+          .filterNot { item =>
+            // Just to be on the safe side, filter out anything that has already ended
+            // (That is, the zoomEnd is less than now)
+            item.zoomEnd.get.toLong < time.now().toEpochMilli
+          }
           .sortBy(_.zoomStart.get.toLong)
 
       // TODO: in theory, we should check that there are no overlapping items in a given room
+
+      println(s"Head of the queue is ${queue.headOption}")
 
       _scheduleQueue.set(queue)
       logger.info(s"Schedule Queue updated -- ${queue.length} items remaining")
@@ -159,14 +168,19 @@ class ScheduleQueueServiceImpl(
     _scheduleQueue.get().headOption match {
       // The item at the front of the queue needs to be started:
       case Some(item) if (item.zoomStart.get.toLong < now.toEpochMilli) => {
-        // Start this item:
-        startProgramItem(item)
         // Note that we intentially do *not* block subsequent items on this one, so that one failure doesn't
         // bring down the whole works. This is sad, but probably correct.
         // Drop it from the head of the queue:
         _scheduleQueue.getAndUpdate(_.tail)
-        // On to the next
-        checkScheduleQueue(now)
+        // Belt and suspenders check: does the database say that this meeting has already started?
+        hasMeetingStarted(item.id).map { hasStarted =>
+          if (!hasStarted) {
+            // Start this item:
+            startProgramItem(item)
+          }
+          // On to the next
+          checkScheduleQueue(now)
+        }
       }
       // We're done:
       case _ => setScheduleCursor(now.toEpochMilli)
@@ -176,8 +190,8 @@ class ScheduleQueueServiceImpl(
   private def checkMeetingsToEnd(now: Instant): Unit = {
     _runningItemsQueue.get().headOption match {
       case Some(item) if (item.endAt.toEpochMilli < now.toEpochMilli) => {
-        endRunningItem(item)
         _runningItemsQueue.getAndUpdate(_.tail)
+        endRunningItem(item)
         checkMeetingsToEnd(now)
       }
       case _ => // Nothing running
@@ -258,6 +272,19 @@ class ScheduleQueueServiceImpl(
       }
       // Someone seems to be confused:
       case _ => Future.successful(Done)
+    }
+  }
+
+  private def hasMeetingStarted(itemId: ProgramItemId): Future[Boolean] = {
+    dbService.run(
+      sql"""
+           SELECT program_item_id
+             FROM active_program_items
+            WHERE program_item_id = ${itemId.v}"""
+        .query[String]
+        .to[List]
+    ).map { existingItems =>
+      !(existingItems.isEmpty)
     }
   }
 


### PR DESCRIPTION
It looks like the ur-cause of the duplicate meetings that have been plaguing us today is the _scheduleCursor, which keeps track of where we are in the Schedule. Which is great in theory, but we were never actually *updating* that cursor in-memory, because I was tired and dumb.

On its own, this was innocuous, because we pull things off the front of the Schedule Queue as we start them. But whenever the Schedule *changes* (which it does fairly often), we would regenerate the whole queue, completely fail to remove the stuff that was already started (because we weren't updating the cursor), and restart all of these already-existing meetings. Hence, bazillions of duplicates.

This fixes that with the one-liner to actually update the cursor where we should have been doing all along.

We also add a belt-and-suspenders check when starting a program item: before doing so, we check the DB to see whether it was already started. In theory this should be irrelevant, but let's be careful.

NB: the reason I didn't notice this before is that bloody Zoom doesn't consider a meeting *real* unless it has two or more people in it. So it has been allowing the system to start lots of conflicting meetings in development without complaining at all.

Finally, this turns the timer back on, to begin starting stuff automatically again, since we believe this fixes the underlying problem.

Fixes #449 