### PR TITLE
Fix PII leak for users without Badge Names

### DIFF
--- a/arisia-remote/app/arisia/auth/LoginService.scala
+++ b/arisia-remote/app/arisia/auth/LoginService.scala
@@ -106,7 +106,7 @@ class LoginServiceImpl(
           EitherT.rightT[Future, LoginError](details)
         else
           EitherT.leftT[Future, LoginUser](LoginError.NoCoC)
-      initialUser = LoginUser(id, badgeName, details.badgeNumber, false, details.membershipType)
+      initialUser = LoginUser(id, badgeName.getOrElse(LoginName.empty), details.badgeNumber, false, details.membershipType)
       _ <- EitherT(recordUserInfo(initialUser))
       withPermissions <- EitherT(checkPermissions(initialUser))
     }

--- a/arisia-remote/app/arisia/discord/DiscordService.scala
+++ b/arisia-remote/app/arisia/discord/DiscordService.scala
@@ -163,7 +163,7 @@ class DiscordServiceImpl(
   }
 
   def setBadgeName(who: LoginUser, memberId: String): Future[Done] = {
-    if (botEnabled) {
+    if (botEnabled && !who.name.isEmpty) {
       ws.url(s"$baseUrl/guilds/$arisiaGuildId/members/${memberId}")
         .addHttpHeaders(
           "Authorization" -> s"Bot $botToken",

--- a/arisia-remote/app/arisia/models/LoginUser.scala
+++ b/arisia-remote/app/arisia/models/LoginUser.scala
@@ -9,8 +9,12 @@ case class LoginId(v: String) extends StdString {
 }
 object LoginId extends StdStringUtils(new LoginId(_))
 
-case class LoginName(v: String) extends StdString
-object LoginName extends StdStringUtils(new LoginName(_))
+case class LoginName(v: String) extends StdString {
+  def isEmpty: Boolean = v.isEmpty
+}
+object LoginName extends StdStringUtils(new LoginName(_)) {
+  val empty = LoginName("")
+}
 
 case class BadgeNumber(v: String) extends StdString
 object BadgeNumber extends StdStringUtils(new BadgeNumber(_))


### PR DESCRIPTION
The (pretty old) CM-webscrape code defaulted, if you didn't have a Badge Name, to using your username. That seemed to make sense at the time, since the username is the primary key to everything, but it needs to be treated as potential PII, because *that* appears to often be peoples' email address. And that problem becomes Much Worse because we change peoples' Discord nickname to be their Badge Name.

So this just turns off that defaulting, and if the Badge Name is empty, doesn't touch the Discord nickname.

Fixes #461 