### PR TITLE
Provisional fix for Show Currently Running Meetings

### DIFF
--- a/arisia-remote/app/arisia/controllers/AdminController.scala
+++ b/arisia-remote/app/arisia/controllers/AdminController.scala
@@ -90,14 +90,14 @@ class AdminController (
     val currentlyRunning = scheduleQueueService.getAllRunningItems()
 
     val results: List[RunningMeetingInfo] =
-      currentlyRunning.toList.map { runningItem =>
-        schedule.byItemId.get(runningItem.itemId).map { item =>
+      currentlyRunning.toList.map { case (itemId, runningMeeting) =>
+        schedule.byItemId.get(itemId).map { item =>
           RunningMeetingInfo(
             item.id.v,
             item.title.map(_.v).getOrElse("Unnamed"),
             item.loc.headOption.map(_.v).getOrElse("Unknown room"),
-           runningItem.meeting.join_url,
-            runningItem.meeting.start_url
+            runningMeeting.meeting.join_url,
+            runningMeeting.meeting.start_url
           )
         }
       }.flatten

--- a/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
+++ b/arisia-remote/app/arisia/schedule/ScheduleQueueService.scala
@@ -30,7 +30,7 @@ trait ScheduleQueueService {
 
   def restartMeeting(id: ProgramItemId): Future[Done]
 
-  def getAllRunningItems(): SortedSet[RunningItem]
+  def getAllRunningItems(): Map[ProgramItemId, RunningItem]
 }
 
 case class RunningItem(endAt: Instant, itemId: ProgramItemId, meeting: ZoomMeeting)
@@ -254,7 +254,7 @@ class ScheduleQueueServiceImpl(
   // The Running Items Queue. Note that this is automatically sorted by the end time:
   val _runningItemsQueue: AtomicReference[SortedSet[RunningItem]] = new AtomicReference(SortedSet.empty)
 
-  def getAllRunningItems(): SortedSet[RunningItem] = _runningItemsQueue.get()
+  def getAllRunningItems(): Map[ProgramItemId, RunningItem] = _currentlyRunningItems.get()
 
   // The Currently Running Items Map, which we fetch meetings from when people want to enter them:
   val _currentlyRunningItems: AtomicReference[Map[ProgramItemId, RunningItem]] = new AtomicReference(Map.empty)


### PR DESCRIPTION
This *may* fix the problem with that page -- certainly it fixes *a* problem with it. (We were previously fetching the prep sessions, but trying to look up the real sessions. I don't know why that was occasionally working: it should have always failed.)

Fixes #463 