### PR TITLE
Fix caching when switching from logged-out to logged-in

### DIFF
--- a/arisia-remote/app/arisia/controllers/ScheduleController.scala
+++ b/arisia-remote/app/arisia/controllers/ScheduleController.scala
@@ -24,13 +24,14 @@ class ScheduleController(
         scheduleService.fullSchedule()
       else
         scheduleService.currentSchedule()
+    val kicker = if (userOpt.isEmpty) "-loggedout" else ""
 
     // The HTTP standard says that the hash should be in double-quotes in both directions:
     //   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
     // Note that the hash is always derived from the current schedule -- the others are based on it, so we
     // don't need to reload unless the base schedule has changed. This saves us from super-expensive
     // recalculations on the program participant schedules.
-    val hashStr = s""""${currentSchedule.hash}""""
+    val hashStr = s""""${currentSchedule.hash}$kicker""""
 
     request.headers.get("If-None-Match") match {
       case Some(prev) if (prev == hashStr) => NotModified


### PR DESCRIPTION
If you logged in as a program participant, and you had previously looked at the Schedule, and it hadn't changed in Zambia, you would still see the logged-out view without your prep sessions. This fixes that, by distinguishing the logged-out ETag.

(Yes, it's a conceptually ugly fix, but it's easy, safe, and works.)

Fixes #466 