### PR TITLE
Fix Profile Page for people who have duplicate login entries

### DIFF
--- a/arisia-remote/app/arisia/auth/LoginService.scala
+++ b/arisia-remote/app/arisia/auth/LoginService.scala
@@ -138,9 +138,12 @@ class LoginServiceImpl(
              FROM user_info
             WHERE badge_number = ${badgeNumber.v}"""
         .query[(String, String, String, String)]
-        .option
+        // TODO: okay, this is just wrong. Badge Number *should* be unique, and this should be `.option`, but
+        // we're somehow getting into a state where people can have duplicate entries in the user_info table.
+        // So for now, we're coping with that. Someday, track down and fix the underlying bug.
+        .to[List]
     ).map {
-      _.map { case (username, badgeName, badgeNumber, membershipType) =>
+      _.headOption.map { case (username, badgeName, badgeNumber, membershipType) =>
           LoginUser(
             LoginId(username),
             LoginName(badgeName),


### PR DESCRIPTION
It looks like you can log in with a space before or after your name, and CM silently allows that. (User 96704 apparently did so.) The result is that they have duplicate entries in user_info. That was causing database errors, which in turn (I suspect) means that their Profile Page was broken.

Ideally we would fix the login pathway, but for now the safer approach is to simply tolerate it.

Fixes #469 