### PR TITLE
Force start/stop

### DIFF
--- a/arisia-remote/app/arisia/views/adminHome.scala.html
+++ b/arisia-remote/app/arisia/views/adminHome.scala.html
@@ -22,7 +22,7 @@
   <h2><a href="/admin/manageTech">Manage Tech</a></h2>
   <h2><a href="/admin/ducks">Manage Ducks</a></h2>
   <h2><a href="/admin/manageMetadata">Manage Metadata</a></h2>
-  <h2><a href="/admin/restart">Restart Meeting</a></h2>
+  <h2><a href="/admin/restart">Start / Stop / Restart Meeting</a></h2>
   <h2><a href="/admin/showStartUrl">Get Start URL for Manually-managed Rooms</a></h2>
   <h2><a href="/admin/showMeetingInfo">Show Currently Running Meetings</a></h2>
 }

--- a/arisia-remote/app/arisia/views/restartMeeting.scala.html
+++ b/arisia-remote/app/arisia/views/restartMeeting.scala.html
@@ -2,7 +2,26 @@
   form: Form[String]
 )(implicit request: RequestHeader, messagesProvider: MessagesProvider)
 
-@main("Restart Meeting") {
+@main("Start / Stop / Restart Meeting") {
+  <h1>Force-Start a Meeting</h1>
+
+  <p>This is only for the situation where you *know* that for some reason that a meeting failed to start.
+  <b>Do not do this without talking to Justin first!</b></p>
+
+  @b4.horizontal.form(arisia.controllers.routes.ZoomController.startProgramItem(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(form("itemId"), Symbol("_label") -> "Program Item ID")
+  }
+
+  <h1>Force-Stop a Meeting</h1>
+
+  <p>This is only for the situation where you *know* that for some reason that a meeting is utterly broken.
+  Usually, this is only for long-dead meetings that are clogging up the view.
+  <b>Do not do this without talking to Justin first!</b></p>
+
+  @b4.horizontal.form(arisia.controllers.routes.ZoomController.stopProgramItem(), "col-md-2", "col-md-10") { implicit hfc =>
+    @b4.text(form("itemId"), Symbol("_label") -> "Program Item ID")
+  }
+
   <h1>Restart Meeting</h1>
 
   <p>This should only be used in the extreme case where a Zoom Host has accidentally shut a Program Item down

--- a/arisia-remote/app/arisia/zoom/ZoomService.scala
+++ b/arisia-remote/app/arisia/zoom/ZoomService.scala
@@ -91,7 +91,7 @@ class ZoomServiceImpl(
           logger.info(s"Meeting $topic started")
           Right(Json.parse(response.body).as[ZoomMeeting])
         } else {
-          val error = s"Failure in trying to start a meeting: ${response.status}"
+          val error = s"Failure in trying to start a meeting: ${response}"
           logger.error(error)
           Left(error)
         }

--- a/arisia-remote/conf/routes
+++ b/arisia-remote/conf/routes
@@ -261,6 +261,8 @@ DELETE  /admin/meeting/:meetingId    arisia.controllers.AdminController.endMeeti
 
 GET     /admin/restart               arisia.controllers.ZoomController.showRestart()
 POST    /admin/restart               arisia.controllers.ZoomController.restartProgramItem()
+POST    /admin/forceStart            arisia.controllers.ZoomController.startProgramItem()
+POST    /admin/forceStop             arisia.controllers.ZoomController.stopProgramItem()
 
 GET     /admin/showStartUrl          arisia.controllers.ZoomController.showGetStartUrl()
 POST    /admin/showStartUrl          arisia.controllers.ZoomController.getStartUrl()


### PR DESCRIPTION
We have a "restart meeting" option, but that's too limited: it only works with meetings that are currently running, but for some reason we can't get to.  (Mainly for when the Zoom Host accidentally kills the meeting.)

This adds two blunter and more commonly-useful hammers:
* Force-start takes any meeting ID, and immediately starts that meeting in its assigned room.  At that point, the usual Join Meeting links should start working.  (This is for when the meeting start failed for some reason.)
* Force-stop takes any meeting ID, and slams it shut.  This is mainly intended for cases where auto-stop failed, and it's just gumming up the database.  (That has been happening a lot, so this is a workaround.)

Fixes #478 