### PR TITLE
Fix login for members of A'22

### DIFF
--- a/arisia-remote/app/arisia/auth/CMService.scala
+++ b/arisia-remote/app/arisia/auth/CMService.scala
@@ -217,6 +217,7 @@ class CMServiceImpl(
         |                          AND events_attended.event_id='32'
         |LEFT JOIN registrant_agreements ON registrant_agreements.uid=registrant_kiosk_login.uid
         |                                AND registrant_agreements.versionID=agreements.versionID
+        |                                AND registrant_agreements.event_id='32'
         |WHERE registrant_kiosk_login.username=$usernameStr;
         """.stripMargin
     run(


### PR DESCRIPTION
Login is failing because we are getting multiple results, and expect to only get one.

The problem is that A'22 (so far) has the same CoC as A'21. So the LEFT JOIN that is pulling in the CoC hits both entries. We need to filter that so that it is only checking your A'21 CoC, not your A'22 one.